### PR TITLE
Fix mode when creating FireHOL ipset directory

### DIFF
--- a/analyzers/FireHOLBlocklists/firehol_blocklists.py
+++ b/analyzers/FireHOLBlocklists/firehol_blocklists.py
@@ -27,7 +27,7 @@ class FireholBlocklistsAnalyzer(Analyzer):
 
         # Check if directory exists
         if not os.path.exists(self.path):
-            os.mkdir(self.path, 0700)
+            os.mkdir(self.path, 0o700)
             # Downloading/updating the list is implemented with an external cronjob which git pulls the repo
 
         # Read files in the given path and prepare file lists for ip- and netsets


### PR DESCRIPTION
Hi,

I tried to use the FireHOL analyzer on last version but encountered the following error when executing it:
```bash
$ ./analyzers/FireHOLBlocklists/firehol_blocklists.py <<< '{"data":"1.2.3.4", "dataType":"ip", "config":{"blocklistpath": "/tmp/firehol"}}'
  File "./analyzers/FireHOLBlocklists/firehol_blocklists.py", line 30
    os.mkdir(self.path, 0700)
                           ^
SyntaxError: invalid token
```

This pull request seems to fix it.

```bash
$ ./analyzers/FireHOLBlocklists/firehol_blocklists.py <<< '{"data":"1.2.3.4", "dataType":"ip", "config":{"blocklistpath": "/tmp/firehol"}}'
{"success": true, "summary": {"taxonomies": [{"level": "safe", "namespace": "Firehol", "predicate": "Blocklists", "value": "\"0 hit\""}]}, "artifacts": [], "full": {"hits": [], "count": 0}}
```

Best regards.