### PR TITLE
Bluecoat analyzer handling of multiple categories and their maliciousness level

### DIFF
--- a/analyzers/Bluecoat/categorization.py
+++ b/analyzers/Bluecoat/categorization.py
@@ -26,8 +26,8 @@ class BluecoatAnalyzer(Analyzer):
         if categorization != "":
             result = {}
             try:
-                result['category'] = re.findall(regex_category, categorization)[0]
-                result['id'] = re.findall(regex_category_id, categorization)[0]
+                result['category'] = ''.join(re.findall(regex_category, categorization))
+                result['id'] =  re.findall(regex_category_id, categorization)[0]
                 result['date'] = re.findall(regex_date, ratedate)
                 if not result['date']:
                     result['date'] = False
@@ -66,13 +66,26 @@ class BluecoatAnalyzer(Analyzer):
 
     def summary(self, raw):
         taxonomies = []
-        level = 'info'
+        categories_string = []
+        level = 'safe'
+        suspicious_categories = ['Scam/Questionable/Illegal','Hacking','Proxy Avoidance','Spam','Suspicious','Placeholders','Phishing','Remote Access Tools','Potentially Unwanted Software','Dynamic DNS Host','Child Pornography']
+        malicious_categories = ['Malicious Outbound Data/Botnets','Malicious Sources/Malnets']
+        info_categories = ['Extreme','Violence/Hate/Racism','Gambling','Nudity','Adult/Mature Content','Peer-to-Peer (P2P)','Pornography','Piracy/Copyright Concerns','Controlled Substances','Uncategorized','Weapons','Marijuana','Computer/Information Security','Internet Connected Devices','Web Ads/Analytics','Mixed Content/Potentially Adult']
+							   
         namespace = 'BlueCoat'
         predicate = 'Category'
         value = '{}'.format(raw['category'])
-
-        if value == '\"Uncategorized\"':
-            level = 'suspicious'
+        categories_string = value.split()
+	
+        for categories in categories_string:
+        	if categories in info_categories:
+        		level = 'info'
+        for categories in categories_string:
+        	if categories in suspicious_categories:
+        		level = 'suspicious'
+        for categories in categories_string:
+        	if value in malicious_categories:
+        		level = 'malicious'
 
         taxonomies.append(self.build_taxonomy(level, namespace, predicate, value))
         return {'taxonomies': taxonomies}
@@ -80,12 +93,12 @@ class BluecoatAnalyzer(Analyzer):
     def run(self):
         json_answer = None
         if self.data_type == 'domain' or self.data_type == 'url' or self.data_type == 'fqdn':
-            if self.data_type == 'url':
+            if self.data_type == 'domain' or self.data_type == 'fqdn':
                 domain = self.url_to_domain(self.getData())
                 if domain:
                     json_answer = self.call_bluecoat_api(domain)
                 else:
-                    self.error('Domain not found')
+                    self.error('Domain of FQDN not found')
 
             else:
                 json_answer = self.call_bluecoat_api(self.getData())

--- a/analyzers/Bluecoat/categorization.py
+++ b/analyzers/Bluecoat/categorization.py
@@ -75,7 +75,7 @@ class BluecoatAnalyzer(Analyzer):
         namespace = 'BlueCoat'
         predicate = 'Category'
         value = '{}'.format(raw['category'])
-        categories_string = value.split()
+        categories_string = value.split(' and ')
 	
         for categories in categories_string:
         	if categories in info_categories:


### PR DESCRIPTION
Since Bluecoat can give URLs multiple categories and this analyzer just handled one I changed the way it works with them. 

The maliciousness level is set to the highest of the categories. In the summary funkction I set the level as I tought it would be most usable. Maybe the community thinks a little bit different, but we will see.

One problem i didn't fix is that the categories have IDs and in the report templates of thehive they are used for linking to the description of Bluecoat. For now only the first found ID is returned.