### PR TITLE
add UnshortenLink analyzer

### DIFF
--- a/analyzers/UnshortenLink/UnshortenLink.json
+++ b/analyzers/UnshortenLink/UnshortenLink.json
@@ -1,0 +1,11 @@
+{
+    "name": "UnshortenLink",
+    "version": "1.0",
+    "author": "Rémi Pointel (CERT-BDF)",
+    "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
+    "license": "AGPL-V3",
+    "description": "Use UnshortenLink to find the correct URL.",
+    "dataTypeList": ["url"],
+    "baseConfig": "UnshortenLink",
+    "command": "UnshortenLink/unshortenlink.py"
+}

--- a/analyzers/UnshortenLink/requirements.txt
+++ b/analyzers/UnshortenLink/requirements.txt
@@ -1,0 +1,2 @@
+requests
+cortexutils

--- a/analyzers/UnshortenLink/unshortenlink.py
+++ b/analyzers/UnshortenLink/unshortenlink.py
@@ -27,10 +27,9 @@ class UnshortenlinkAnalyzer(Analyzer):
         else:
             proxies = {}
 
+        result = {'found': False, 'url': None}
         try:
             response = requests.get(url, proxies=proxies, allow_redirects=False) 
-    
-            result = {'found': False, 'url': None}
         
             if (response.status_code == 301) or (response.status_code == 302):
                 result['url'] = response.headers['Location']

--- a/analyzers/UnshortenLink/unshortenlink.py
+++ b/analyzers/UnshortenLink/unshortenlink.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python3
 # encoding: utf-8
 
-from base64 import b64encode
-import json
-import urllib.parse
-import http.client
+import requests
 from cortexutils.analyzer import Analyzer
 
 class UnshortenlinkAnalyzer(Analyzer):
@@ -23,74 +20,25 @@ class UnshortenlinkAnalyzer(Analyzer):
     def run(self):
         Analyzer.run(self)
 
-        data = self.getData()
+        url = self.getData()
 
-        if self.proxies is None:
-            try:
-                url_parsed = urllib.parse.urlparse(data)
-    
-                if url_parsed.scheme == "https":
-                    h = http.client.HTTPSConnection(url_parsed.netloc)
-                elif url_parsed.scheme == "http":
-                    h = http.client.HTTPConnection(url_parsed.netloc)
-    
-                h.request('HEAD', url_parsed.path)
-                response = h.getresponse()
-    
-                result = {'found': False, 'url': None}
-    
-                if (response.status == 301) or (response.status == 302):
-                    result['url'] = response.getheader('Location')
-                    result['found'] = True
-    
-                self.report(result)
-            except:
-                self.unexpectedError("Service unavailable")
+        if self.proxies:
+            proxies = self.proxies
         else:
-            try:
-                # use https if used
-                if self.proxies.get("https"):
-                    proxy_parsed = urllib.parse.urlparse(self.proxies.get("https"))
-                    h = http.client.HTTPSConnection(proxy_parsed.hostname, proxy_parsed.port)
-                else:
-                    proxy_parsed = urllib.parse.urlparse(self.proxies.get("http"))
-                    h = http.client.HTTPConnection(proxy_parsed.hostname, proxy_parsed.port)
+            proxies = {}
 
-                headers = {}
-                if proxy_parsed.username and proxy_parsed.password:
-                    auth = "%s:%s" % (proxy_parsed.username, proxy_parsed.password)
-                    headers['Proxy-Authorization'] = 'Basic ' + b64encode(auth)
+        try:
+            response = requests.get(url, proxies=proxies, allow_redirects=False) 
+    
+            result = {'found': False, 'url': None}
+        
+            if (response.status_code == 301) or (response.status_code == 302):
+                result['url'] = response.headers['Location']
+                result['found'] = True
+        except Exception as e:
+            self.unexpectedError("Service unavailable: %s" % e)
 
-                #url_parsed = urllib.parse.urlparse(data)
-
-                #if (url_parsed.scheme == "https") and (url_parsed.port is None):
-                #    url_parsed_port = 443
-                #else:
-                #    url_parsed_port = url_parsed.port
-
-                #if url_parsed.path is None:
-                #    url_parsed_path = "/"
-                #else:
-                #    url_parsed_path = url_parsed.path
-
-                try:
-                    #h.set_tunnel(url_parsed.hostname, url_parsed_port, headers)
-                    h.request('HEAD', data)
-                    response = h.getresponse()
-                except Exception as e:
-                    self.unexpectedError("Service unavailable, exception: %s" % e)
-
-                result = {'found': False, 'url': None}
-
-                if (response.status == 301) or (response.status == 302):
-                    result['url'] = response.getheader('Location')
-                    result['found'] = True
-                    self.report(result)
-                    return
-
-                self.report(result)
-            except:
-                self.unexpectedError("Service unavailable")
+        self.report(result)
 
 if __name__ == '__main__':
     UnshortenlinkAnalyzer().run()

--- a/analyzers/UnshortenLink/unshortenlink.py
+++ b/analyzers/UnshortenLink/unshortenlink.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
+from base64 import b64encode
+import json
+import urllib.parse
+import http.client
+from cortexutils.analyzer import Analyzer
+
+class UnshortenlinkAnalyzer(Analyzer):
+
+    def __init__(self):
+        Analyzer.__init__(self)
+        self.url = self.getParam('url', None)
+        self.proxies = self.getParam('config.proxy', None)
+
+    def artifacts(self, raw):
+        if raw['found'] == True:
+            return [{'type': 'url', 'value': raw['url']}]
+        else:
+            return []
+
+    def run(self):
+        Analyzer.run(self)
+
+        data = self.getData()
+
+        if self.proxies is None:
+            try:
+                url_parsed = urllib.parse.urlparse(data)
+    
+                if url_parsed.scheme == "https":
+                    h = http.client.HTTPSConnection(url_parsed.netloc)
+                elif url_parsed.scheme == "http":
+                    h = http.client.HTTPConnection(url_parsed.netloc)
+    
+                h.request('HEAD', url_parsed.path)
+                response = h.getresponse()
+    
+                result = {'found': False, 'url': None}
+    
+                if (response.status == 301) or (response.status == 302):
+                    result['url'] = response.getheader('Location')
+                    result['found'] = True
+    
+                self.report(result)
+            except:
+                self.unexpectedError("Service unavailable")
+        else:
+            try:
+                # use https if used
+                if self.proxies.get("https"):
+                    proxy_parsed = urllib.parse.urlparse(self.proxies.get("https"))
+                    h = http.client.HTTPSConnection(proxy_parsed.hostname, proxy_parsed.port)
+                else:
+                    proxy_parsed = urllib.parse.urlparse(self.proxies.get("http"))
+                    h = http.client.HTTPConnection(proxy_parsed.hostname, proxy_parsed.port)
+
+                headers = {}
+                if proxy_parsed.username and proxy_parsed.password:
+                    auth = "%s:%s" % (proxy_parsed.username, proxy_parsed.password)
+                    headers['Proxy-Authorization'] = 'Basic ' + b64encode(auth)
+
+                #url_parsed = urllib.parse.urlparse(data)
+
+                #if (url_parsed.scheme == "https") and (url_parsed.port is None):
+                #    url_parsed_port = 443
+                #else:
+                #    url_parsed_port = url_parsed.port
+
+                #if url_parsed.path is None:
+                #    url_parsed_path = "/"
+                #else:
+                #    url_parsed_path = url_parsed.path
+
+                try:
+                    #h.set_tunnel(url_parsed.hostname, url_parsed_port, headers)
+                    h.request('HEAD', data)
+                    response = h.getresponse()
+                except Exception as e:
+                    self.unexpectedError("Service unavailable, exception: %s" % e)
+
+                result = {'found': False, 'url': None}
+
+                if (response.status == 301) or (response.status == 302):
+                    result['url'] = response.getheader('Location')
+                    result['found'] = True
+                    self.report(result)
+                    return
+
+                self.report(result)
+            except:
+                self.unexpectedError("Service unavailable")
+
+if __name__ == '__main__':
+    UnshortenlinkAnalyzer().run()

--- a/analyzers/UnshortenLink/unshortenlink.py
+++ b/analyzers/UnshortenLink/unshortenlink.py
@@ -4,15 +4,15 @@
 import requests
 from cortexutils.analyzer import Analyzer
 
-class UnshortenlinkAnalyzer(Analyzer):
 
+class UnshortenlinkAnalyzer(Analyzer):
     def __init__(self):
         Analyzer.__init__(self)
         self.url = self.getParam('url', None)
         self.proxies = self.getParam('config.proxy', None)
 
     def artifacts(self, raw):
-        if raw['found'] == True:
+        if raw['found']:
             return [{'type': 'url', 'value': raw['url']}]
         else:
             return []
@@ -29,8 +29,9 @@ class UnshortenlinkAnalyzer(Analyzer):
 
         result = {'found': False, 'url': None}
         try:
-            response = requests.get(url, proxies=proxies, allow_redirects=False) 
-        
+            response = requests.get(url, proxies=proxies,
+                                    allow_redirects=False)
+
             if (response.status_code == 301) or (response.status_code == 302):
                 result['url'] = response.headers['Location']
                 result['found'] = True
@@ -38,6 +39,7 @@ class UnshortenlinkAnalyzer(Analyzer):
             self.unexpectedError("Service unavailable: %s" % e)
 
         self.report(result)
+
 
 if __name__ == '__main__':
     UnshortenlinkAnalyzer().run()

--- a/thehive-templates/UnshortenLink_1_0/long.html
+++ b/thehive-templates/UnshortenLink_1_0/long.html
@@ -1,0 +1,19 @@
+<div class="panel panel-info" ng-if="success">
+    <div class="panel-heading">
+        Unshorten Link for <strong>{{artifact.data | fang}}</strong>
+    </div>
+    <div class="panel-body">
+            <span>found:{{content.found}}</span>
+        <div ng-if="content.found">
+            <span>url:{{content.url | fang}}</span>
+        </div>
+    </div>
+</div>
+<div class="panel panel-danger" ng-if="!success">
+    <div class="panel-heading">
+        <strong>{{artifact.data | fang}}</strong>
+    </div>
+    <div class="panel-body">
+        {{content.errorMessage}}
+    </div>
+</div>


### PR DESCRIPTION
Hi,

UnshortenLink is an analyzer to find URL behind 301 or 302 redirects (tinyurl).

Example: you have one observable with dataType":"url" and data:"https://t.co/lw0xAzJFeL", it finds that the URL is "http://blog.thehive-project.org/2017/12/20/cerana-0-2-x-pack-auth-multi-source-dashboards/"

Ok?

Cheers,

Remi.