### PR TITLE
VirusTotal URL report

### DIFF
--- a/analyzers/VirusTotal/VirusTotal_GetReport.json
+++ b/analyzers/VirusTotal/VirusTotal_GetReport.json
@@ -5,7 +5,7 @@
   "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
   "license": "AGPL-V3",
   "description": "Get the latest VirusTotal report for a file, hash, domain or an IP address.",
-  "dataTypeList": ["file", "hash", "domain", "ip"],
+  "dataTypeList": ["file", "hash", "domain", "ip", "url"],
   "command": "VirusTotal/virustotal.py",
   "baseConfig": "VirusTotal",
   "config": {

--- a/analyzers/VirusTotal/virustotal.py
+++ b/analyzers/VirusTotal/virustotal.py
@@ -152,7 +152,6 @@ class VirusTotalAnalyzer(Analyzer):
                 data = self.get_param('data', None, 'Data is missing')
                 self.report(self.check_response(self.vt.get_ip_report(data)))
             elif self.data_type == 'file':
-
                 hashes = self.get_param('attachment.hashes', None)
                 if hashes is None:
                     filepath = self.get_param('file', None, 'File is missing')
@@ -162,10 +161,12 @@ class VirusTotalAnalyzer(Analyzer):
                     hash = next(h for h in hashes if len(h) == 64)
 
                 self.report(self.check_response(self.vt.get_file_report(hash)))
-
             elif self.data_type == 'hash':
                 data = self.get_param('data', None, 'Data is missing')
                 self.report(self.check_response(self.vt.get_file_report(data)))
+            elif self.data_type == 'url':
+                data = self.get_param('data', None, 'Data is missing')
+                self.report(self.check_response(self.vt.get_url_report(data)))
             else:
                 self.error('Invalid data type')
         else:

--- a/thehive-templates/VirusTotal_GetReport_3_0/long.html
+++ b/thehive-templates/VirusTotal_GetReport_3_0/long.html
@@ -67,6 +67,10 @@
                             <a ng-href="https://www.virustotal.com/#/file/{{artifact.data}}/detection" target="_blank">
                                 View Full Report</a>
                         </span>
+                        <span ng-if="artifact.dataType === 'url'">
+                            <i class="fa fa-search"></i>
+                            <a ng-href="{{content.permalink}}" target="_blank">View Full Report</a>
+                        </span>
                     </dd>
                 </dl>
             </div>


### PR DESCRIPTION
The VirusTotal analyzer is currenlty able to scan an URL but not only get the report of the last analysis, which limit the capacity of Cortex dealing with URLs.

This pull request add the ability to the VirusTotal analyzer to only get report for a specified URL.

Please tell me if something needs to be reworked.