### PR TITLE
adding Clam Analyzer

### DIFF
--- a/analyzers/ClamAV-CortexAnalyzer/clam.json
+++ b/analyzers/ClamAV-CortexAnalyzer/clam.json
@@ -1,0 +1,12 @@
+{
+  "name": "Clamscan",
+  "version": "1.1",
+  "author": "Brian Laskowski",
+  "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
+  "license": "AGPL-V3",
+  "description": "Use Clamscan with custom rules",
+  "dataTypeList": ["file"],
+  "baseConfig": "ClamScan",
+  "command": "ClamAV-CortexAnalyzer/pyclam_analyzer.py"
+}
+

--- a/analyzers/ClamAV-CortexAnalyzer/long.html
+++ b/analyzers/ClamAV-CortexAnalyzer/long.html
@@ -1,0 +1,33 @@
+<div class="panel panel-danger" ng-if="success && content.results.length > 0">
+	<div class="panel-heading">
+		ClamAV Report
+	</div>
+	<div class="panel-body">
+		<dl class="dl-horizontal">
+			<dt>Matches</dt>
+			<dd ng-repeat="m in content.results">{{m}}</dd>
+		</dl>
+	</div>
+</div>
+<div class="panel panel-success" ng-if="success && content.results.length == 0">
+	<div class="panel-heading">
+		ClamAV Report
+	</div>
+	<div class="panel-body">
+		<span>No matches.</span>
+	</div>
+</div>
+
+<!-- General error  -->
+<div class="panel panel-danger" ng-if="!success">
+    <div class="panel-heading">
+        <strong>{{(artifact.data || artifact.attachment.name) | fang}}</strong>
+    </div>
+    <div class="panel-body">
+    	<dl class="dl-horizontal" ng-if="content.errorMessage">
+            <dt><i class="fa fa-warning"></i> ClamAV : </dt>
+            <dd class="wrap">{{content.errorMessage}}</dd>
+        </dl>
+    </div>
+</div>
+

--- a/analyzers/ClamAV-CortexAnalyzer/pyclam_analyzer.py
+++ b/analyzers/ClamAV-CortexAnalyzer/pyclam_analyzer.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+from cortexutils.analyzer import Analyzer
+
+import os
+import pyclamd
+
+cd = pyclamd.ClamdUnixSocket()
+
+class ClamAnalyzer(Analyzer):
+    """This is a minimal analyzer that just does nothing other than returning an empty result. It can be used as
+    skeleton when creating new analyzers."""
+
+    def __init__(self):
+        """Initialization of the class. Here normally all parameters are read using `self.get_param`
+        (or `self.getParam`)"""
+        Analyzer.__init__(self)
+
+
+    def check(self, file: str) -> list:
+        """
+        Checks a given file against all available yara rules
+
+        :param file: Path to file
+        :returns: Python dictionary containing the results
+        """
+        result = []
+        match = cd.scan_file(file)
+        result.append(str(match))
+        
+        return result
+
+
+   # def summary(self, raw):
+    #    return raw
+    def summary(self, raw):
+        taxonomies = []
+        namespace = "Clamscan"
+        predicate = "Match"
+
+        value = "{} rule(s)".format(len(raw["results"]))        
+        if len(str(raw["results"])) < 12:            
+            level = "safe"
+        else:
+            level = "malicious"
+
+        taxonomies.append(self.build_taxonomy(level, namespace, predicate, value))
+        return {"taxonomies": taxonomies}
+
+
+    def run(self):
+        if self.data_type == 'file':
+            self.report({'results': self.check(self.getParam('file'))})
+        else:
+            self.error('Wrong data type.')
+
+if __name__ == '__main__':
+    """This is necessary, because it is called from the CLI."""
+    ClamAnalyzer().run()

--- a/analyzers/ClamAV-CortexAnalyzer/requirements.txt
+++ b/analyzers/ClamAV-CortexAnalyzer/requirements.txt
@@ -1,0 +1,2 @@
+cortexutils
+pyclamd

--- a/analyzers/ClamAV-CortexAnalyzer/short.html
+++ b/analyzers/ClamAV-CortexAnalyzer/short.html
@@ -1,0 +1,3 @@
+<span class="label" ng-repeat="t in content.taxonomies" ng-class="{'info': 'label-info', 'safe': 'label-success', 'suspicious': 'label-warning', 'malicious':'label-danger'}[t.level]">
+    {{t.namespace}}:{{t.predicate}}={{t.value}}
+</span>


### PR DESCRIPTION
Pull request for issue:
ClamAV New analyzer #311

ClamAV has become a very useful open source AV and general purpose scanner. I find it most useful in being able to parse Yara rules and the inclusion of sigtool to create your own Clam rule sets.

While I run this locally on many linux servers with my own script. I often have new samples that are not in my existing rules, I've wanted a way to be able to ingest my rules into TheHive, I was using the yara analyzer but it has had some hiccups with v2 of Cortex. This led me to build the following using the base code from other scanners.

walk through provided here: 
https://laskowski-tech.com/2018/07/24/clamav-analyzer-for-thehive-and-cortex/
