### PR TITLE
Redmine responder

### DIFF
--- a/responders/Redmine/Redmine_Issue.json
+++ b/responders/Redmine/Redmine_Issue.json
@@ -1,0 +1,64 @@
+{
+  "name": "Redmine_Issue",
+  "version": "1.0",
+  "author": "Marc-André DOLL",
+  "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
+  "license": "AGPL-V3",
+  "description": "Create a redmine issue from a case",
+  "dataTypeList": [
+    "thehive:case"
+  ],
+  "command": "Redmine/redmine.py",
+  "baseConfig": "Redmine",
+  "configurationItems": [
+    {
+      "name": "url",
+      "description": "URL where to find the Redmine API",
+      "type": "string",
+      "multi": false,
+      "required": true
+    },
+    {
+      "name": "username",
+      "description": "Username to log into Redmine",
+      "type": "string",
+      "multi": false,
+      "required": true
+    },
+    {
+      "name": "password",
+      "description": "Password to log into Redmine",
+      "type": "string",
+      "multi": false,
+      "required": true
+    },
+    {
+      "name": "project_field",
+      "description": "Name of the custom field containing the Redmine project to use when craeting the issue",
+      "multi": false,
+      "required": true,
+      "type": "string"
+    },
+    {
+      "name": "tracker_field",
+      "description": "Name of the custom field containing the Redmine tracker to use when craeting the issue",
+      "multi": false,
+      "required": true,
+      "type": "string"
+    },
+    {
+      "name": "assignee_field",
+      "description": "Name of the custom field containing the Redmine assignee to use when craeting the issue",
+      "multi": false,
+      "required": false,
+      "type": "string"
+    },
+    {
+      "name": "opening_status",
+      "description": "Status used when opening a Redmine issue (if not defined here, will use the default opening status from the Redmine Workflow)",
+      "type": "string",
+      "multi": false,
+      "required": false
+    }
+  ]
+}

--- a/responders/Redmine/Redmine_Issue.json
+++ b/responders/Redmine/Redmine_Issue.json
@@ -6,7 +6,8 @@
   "license": "AGPL-V3",
   "description": "Create a redmine issue from a case",
   "dataTypeList": [
-    "thehive:case", "thehive:case_task"
+    "thehive:case",
+    "thehive:case_task"
   ],
   "command": "Redmine/redmine.py",
   "baseConfig": "Redmine",
@@ -42,24 +43,31 @@
     },
     {
       "name": "project_field",
-      "description": "Name of the custom field containing the Redmine project to use when craeting the issue",
+      "description": "Name of the custom field containing the Redmine project to use when creating the issue",
       "multi": false,
       "required": true,
       "type": "string"
     },
     {
       "name": "tracker_field",
-      "description": "Name of the custom field containing the Redmine tracker to use when craeting the issue",
+      "description": "Name of the custom field containing the Redmine tracker to use when creating the issue",
       "multi": false,
       "required": true,
       "type": "string"
     },
     {
       "name": "assignee_field",
-      "description": "Name of the custom field containing the Redmine assignee to use when craeting the issue",
+      "description": "Name of the custom field containing the Redmine assignee to use when creating the issue",
       "multi": false,
       "required": false,
       "type": "string"
+    },
+    {
+      "name": "reference_field",
+      "description": "Name of the case custom field in which to store the opened issue. If not defined, this information will not be stored",
+      "type": "string",
+      "required": false,
+      "multi": false
     },
     {
       "name": "opening_status",

--- a/responders/Redmine/Redmine_Issue.json
+++ b/responders/Redmine/Redmine_Issue.json
@@ -6,7 +6,7 @@
   "license": "AGPL-V3",
   "description": "Create a redmine issue from a case",
   "dataTypeList": [
-    "thehive:case"
+    "thehive:case", "thehive:case_task"
   ],
   "command": "Redmine/redmine.py",
   "baseConfig": "Redmine",

--- a/responders/Redmine/Redmine_Issue.json
+++ b/responders/Redmine/Redmine_Issue.json
@@ -12,6 +12,14 @@
   "baseConfig": "Redmine",
   "configurationItems": [
     {
+      "name": "instance_name",
+      "description": "Name of the Redmine instance",
+      "multi": false,
+      "required": false,
+      "type": "string",
+      "defaultValue": "redmine"
+    },
+    {
       "name": "url",
       "description": "URL where to find the Redmine API",
       "type": "string",

--- a/responders/Redmine/Redmine_Issue.json
+++ b/responders/Redmine/Redmine_Issue.json
@@ -75,6 +75,14 @@
       "type": "string",
       "multi": false,
       "required": false
+    },
+    {
+      "name": "closing_task",
+      "description": "Closing the task after successfully creating the Redmine issue",
+      "type": "boolean",
+      "multi": false,
+      "defaultValue": false,
+      "required": false
     }
   ]
 }

--- a/responders/Redmine/redmine.py
+++ b/responders/Redmine/redmine.py
@@ -7,8 +7,10 @@ import redmine_client
 class Redmine(Responder):
     def __init__(self):
         Responder.__init__(self)
+        self.instance_name = self.get_param('config.instance_name', 'redmine')
+        self.instance_url = self.get_param('config.url', None, 'Missing Redmine URL')
         self.client = redmine_client.RedmineClient(
-            baseurl=self.get_param('config.url', None, 'Missing Redmine URL'),
+            baseurl=self.instance_url,
             username=self.get_param('config.username', None, 'Missing username'),
             password=self.get_param('config.password', None, 'Missing password'))
         self.project_field = self.get_param('config.project_field', None, 'Missing custom field for Redmine project')
@@ -33,7 +35,11 @@ class Redmine(Responder):
                     title=title, body=description, project=project, tracker=tracker,
                     status=self.get_param('config.opening_status'), priority=self.get_param('data.severity'),
                     assignee=assignee)
-                self.report({'message': 'issue {} created'.format(issue['issue']['id']), 'issue': issue})
+                self.report({
+                    'message': 'issue {} created'.format(issue['issue']['id']),
+                    'instance': {'name': self.instance_name, "url": self.instance_url}, 
+                    'issue': issue
+                })
             except Exception as e:
                 self.error(str(e))
         else:

--- a/responders/Redmine/redmine.py
+++ b/responders/Redmine/redmine.py
@@ -16,6 +16,7 @@ class Redmine(Responder):
         self.project_field = self.get_param('config.project_field', None, 'Missing custom field for Redmine project')
         self.tracker_field = self.get_param('config.tracker_field', None, 'Missing custom field for Redmine tracker')
         self.assignee_field = self.get_param('config.assignee_field', None, 'Missing custom field for Redmine assignee')
+        self.reference_field = self.get_param('config.reference_field', None)
 
     def run(self):
         issue_data = {}
@@ -41,6 +42,8 @@ class Redmine(Responder):
 
     def operations(self, raw):
         ops = []
+        if self.reference_field:
+            ops.append(self.build_operation('AddCustomFields', name=self.reference_field, tpe='string', value='{}#{}'.format(self.instance_name, raw['issue']['issue']['id'])))
         if self.data_type == 'thehive:case_task':
             ops.append(self.build_operation('CloseTask'))
         return ops

--- a/responders/Redmine/redmine.py
+++ b/responders/Redmine/redmine.py
@@ -17,6 +17,7 @@ class Redmine(Responder):
         self.tracker_field = self.get_param('config.tracker_field', None, 'Missing custom field for Redmine tracker')
         self.assignee_field = self.get_param('config.assignee_field', None, 'Missing custom field for Redmine assignee')
         self.reference_field = self.get_param('config.reference_field', None)
+        self.closing_task = self.get_param('config.closing_task', False)
 
     def run(self):
         issue_data = {}
@@ -44,7 +45,7 @@ class Redmine(Responder):
         ops = []
         if self.reference_field:
             ops.append(self.build_operation('AddCustomFields', name=self.reference_field, tpe='string', value='{}#{}'.format(self.instance_name, raw['issue']['issue']['id'])))
-        if self.data_type == 'thehive:case_task':
+        if self.data_type == 'thehive:case_task' and self.closing_task:
             ops.append(self.build_operation('CloseTask'))
         return ops
 

--- a/responders/Redmine/redmine.py
+++ b/responders/Redmine/redmine.py
@@ -39,6 +39,12 @@ class Redmine(Responder):
         except Exception as e:
             self.error(str(e))
 
+    def operations(self, raw):
+        ops = []
+        if self.data_type == 'thehive:case_task':
+            ops.append(self.build_operation('CloseTask'))
+        return ops
+
     def extract_case_data(self, data_root='data'):
         issue_data = {}
         issue_data['title'] = self.get_param('{}.title'.format(data_root), None, 'Case title is missing')

--- a/responders/Redmine/redmine.py
+++ b/responders/Redmine/redmine.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
+from cortexutils.responder import Responder
+import redmine_client
+
+class Redmine(Responder):
+    def __init__(self):
+        Responder.__init__(self)
+        self.client = redmine_client.RedmineClient(
+            baseurl=self.get_param('config.url', None, 'Missing Redmine URL'),
+            username=self.get_param('config.username', None, 'Missing username'),
+            password=self.get_param('config.password', None, 'Missing password'))
+        self.project_field = self.get_param('config.project_field', None, 'Missing custom field for Redmine project')
+        self.tracker_field = self.get_param('config.tracker_field', None, 'Missing custom field for Redmine tracker')
+        self.assignee_field = self.get_param('config.assignee_field', None, 'Missing custom field for Redmine assignee')
+
+    def run(self):
+        if self.data_type == 'thehive:case':
+            title = self.get_param('data.title', None, 'title is missing')
+            description = self.get_param('data.description', None, 'description is missing')
+            project = None
+            tracker = None
+            assignee = None
+            if self.project_field:
+                project = self.get_param('data.customFields.{}.string'.format(self.project_field), None, 'Project not defined in case')
+            if self.tracker_field:
+                tracker = self.get_param('data.customFields.{}.string'.format(self.tracker_field), None, 'Tracker not defined in case')
+            if self.assignee_field:
+                assignee = self.get_param('data.customFields.{}.string'.format(self.assignee_field), None)
+            try:
+                issue = self.client.create_issue(
+                    title=title, body=description, project=project, tracker=tracker,
+                    status=self.get_param('config.opening_status'), priority=self.get_param('data.severity'),
+                    assignee=assignee)
+                self.report({'message': 'issue {} created'.format(issue['issue']['id']), 'issue': issue})
+            except Exception as e:
+                self.error(str(e))
+        else:
+            self.error('Invalid dataType')
+
+if __name__ == '__main__':
+    Redmine().run()

--- a/responders/Redmine/redmine_client.py
+++ b/responders/Redmine/redmine_client.py
@@ -1,0 +1,77 @@
+import requests
+
+class RedmineClient:
+    def __init__(self, baseurl, username, password):
+        self.base_url = baseurl
+        self.session = requests.Session()
+        self.session.headers.update({'content-type': 'application/json'})
+        self.session.auth = (username, password)
+
+    def create_issue(self, title=None, body=None, project=None, tracker=None,
+                     priority=None, status=None, assignee=None):
+        payload = {
+            'issue': {
+                'subject': title,
+                'description': body,
+                'project_id': project,
+                'tracker_id':  self.get_tracker_id(tracker),
+                'priority_id': priority,
+                'status_id':   self.get_status_id(status),
+                'assigned_to_id': self.get_assignee_id(project, assignee)
+            }
+        }
+        url = self.base_url + '/issues.json'
+        response = self.session.post(url, json=payload)
+        response.raise_for_status()
+        result = response.json()
+        if 'error' in result:
+            raise RedmineClientError(result['error'])
+        return result
+
+    def get_tracker_id(self, name):
+        url = self.base_url + '/trackers.json'
+        id = None
+        trackers = self.session.get(url)
+        trackers.raise_for_status()
+        for p in trackers.json()['trackers']:
+            if p['name'] == name:
+                id = p['id']
+                break
+        return id
+
+    def get_status_id(self, name):
+        url = self.base_url + '/issue_statuses.json'
+        id = None
+        issue_statuses = self.session.get(url)
+        issue_statuses.raise_for_status()
+        for p in issue_statuses.json()['issue_statuses']:
+            if p['name'] == name:
+                id = p['id']
+                break
+        return id
+
+    def get_assignee_id(self, project, assignee):
+        url = '{}/projects/{}/memberships.json'.format(self.base_url, project)
+        id = None
+        payload = {'offset': 0}
+        total_count = 0
+        while id is None and payload['offset'] <= total_count:
+            response = self.session.get(url, params=payload)
+            response.raise_for_status()
+            for member in response.json()['memberships']:
+                if 'user' in member:
+                    if assignee == member['user']['name']:
+                        id = member['user']['id']
+                        break
+                elif 'group' in member:
+                    if assignee == member['group']['name']:
+                        id = member['group']['id']
+                        break
+            total_count = response.json()['total_count']
+            payload['offset'] += response.json()['limit']
+        return id
+
+
+class RedmineClientError(Exception):
+    def __init__(self, message):
+        self.message = message

--- a/responders/Redmine/requirements.txt
+++ b/responders/Redmine/requirements.txt
@@ -1,0 +1,2 @@
+requests
+cortexutils


### PR DESCRIPTION
Hi,

Here is a first draft for a responder used to create an issue in the Redmine ticketing system from a case. It will use the case title as the issue subject and the case description as the issue body. It will also use the case severity as the issue priority with the following mapping:

| case   | issue  |
|--------|--------|
| low    | low    |
| medium | normal |
| high   | high   |

To set it up in Cortex, you will need:
* To define a user to allow Cortex to connect to Redmine and with access on the various project in which issues should be created
* Define three custom fields in TheHive that will be used to select the project, the tracker and the assignee of the issue (the latest being optional) Those fields can be let free or can be custom fields with preset values

This is a minimal product (I am able to create an issue with the few parameters sent to Redmine) but here is a list on what I would keep on working to improve the responder:
- [ ] Allow custom priority mapping
- [ ] Allow filling Redmine custom fields
- [ ] Push attachments of case as issue attachments
- [x] Set responder operation to fill a custom field with the issue id
- [x] Be able to call the responder from an alert or a task