### PR TITLE
Add RecordedFuture Analyzer

### DIFF
--- a/analyzers/RecordedFuture/RecordedFuture_risk.json
+++ b/analyzers/RecordedFuture/RecordedFuture_risk.json
@@ -1,0 +1,20 @@
+{
+  "name": "RecordedFuture_risk",
+  "version": "1.0",
+  "author": "KAPSCH-CDC",
+  "url": "https://github.com/kapschcdc/Cortex-Analyzers",
+  "license": "AGPL-V3",
+  "description": "Get the latest risk data from RecordedFuture for a hash, domain or an IP address.",
+  "dataTypeList": ["domain", "ip", "hash"],
+  "command": "RecordedFuture/recordedfuture.py",
+  "baseConfig": "RecordedFuture",
+  "configurationItems": [
+    {
+      "name": "key",
+      "description": "API key for RecordedFuture",
+      "type": "string",
+      "multi": false,
+      "required": true
+    }
+  ]
+}

--- a/analyzers/RecordedFuture/recordedfuture.py
+++ b/analyzers/RecordedFuture/recordedfuture.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from cortexutils.analyzer import Analyzer
+
+import urllib.request
+import json
+
+class RecordedFutureAnalyzer(Analyzer):
+    def __init__(self):
+        Analyzer.__init__(self)
+        self.recordedfuture_key = self.get_param('config.key', None, 'Missing RecordedFuture API key')
+        self.proxies = self.get_param('config.proxy', None)
+
+    def summary(self, raw):
+        taxonomies = []
+        namespace = 'RF'
+
+        level = 'info'
+        predicate = 'score'
+        value = '{}/100'.format(raw['data']['risk']['score'])
+        criticality = raw['data']['risk']['criticality']
+        if criticality == 0:
+            level = 'safe'
+        elif criticality == 1:
+            level = 'info'
+        elif criticality == 2:
+            level = 'suspicious'
+        elif criticality >= 3:
+            level = 'malicious'
+        taxonomies.append(self.build_taxonomy(level, namespace, predicate, value))
+
+        level = 'info'
+        predicate = '#evidenceDetails'
+        value = str(len(raw['data']['risk']['evidenceDetails']))
+        taxonomies.append(self.build_taxonomy(level, namespace, predicate, value))
+
+        return {"taxonomies": taxonomies}
+
+    def run(self):
+        if self.data_type in ['domain', 'ip', 'hash']:
+            data = self.get_param('data', None, 'Data is missing')
+            url = 'https://api.recordedfuture.com/v2/{}/{}?fields=risk%2CintelCard'.format(self.data_type, data)
+            req = urllib.request.Request(url, None, {'X-RFToken': self.recordedfuture_key})
+            try:
+                with urllib.request.urlopen(req) as res:
+                    j = json.loads(res.read().decode("utf-8"))
+                    self.summary(j)
+                    return self.report(j)
+            except IOError as e:
+                self.error(str(e))
+        else:
+            self.error('Invalid data type')
+
+if __name__ == '__main__':
+    RecordedFutureAnalyzer().run()

--- a/analyzers/RecordedFuture/requirements.txt
+++ b/analyzers/RecordedFuture/requirements.txt
@@ -1,0 +1,1 @@
+cortexutils

--- a/thehive-templates/RecordedFuture_risk_1_0/long.html
+++ b/thehive-templates/RecordedFuture_risk_1_0/long.html
@@ -1,0 +1,55 @@
+<!-- Success -->
+<div class="panel panel-info" ng-if="success">
+    <div class="panel-heading">
+        <strong>Summary</strong>
+    </div>
+    <div class="panel-body">
+        <dl class="dl-horizontal">
+            <dt>Score</dt>
+            <dd>{{content.data.risk.score}}/100</dd>
+        </dl>
+        <dl class="dl-horizontal">
+            <dt>Criticality</dt>
+            <dd>{{content.data.risk.criticalityLabel}} ({{content.data.risk.criticality}})</dd>
+        </dl>
+        <dl class="dl-horizontal">
+            <dt>Risk summary</dt>
+            <dd>{{content.data.risk.riskSummary}}</dd>
+        </dl>
+        <a href="{{content.data.intelCard}}" target="_blank" class="btn btn-primary" role="button">Intel Card</a>
+    </div>
+    <div class="panel-heading">
+        <strong>Triggered Risk Rules</strong>
+    </div>
+    <div class="panel-body">
+        <table class="table table-hover">
+            <tr>
+                <th>Criticality</th>
+                <th>Rule</th>
+                <th>Evidence</th>
+            </tr>
+            <tr ng-repeat="evidence in content.data.risk.evidenceDetails">
+                <td>
+                    <span ng-class="{'text-success': evidence.criticality == 0, 'text-warning': evidence.criticality > 0, 'text-danger': evidence.criticality > 2}">
+                        {{evidence.criticalityLabel}}
+                    </span>
+                </td>
+                <td>{{evidence.rule}}</td>
+                <td class="wrap">{{evidence.evidenceString}}</td>
+            </tr>
+        </table>
+    </div>
+</div>
+
+<!-- General error  -->
+<div class="panel panel-danger" ng-if="!success">
+    <div class="panel-heading">
+        <strong>{{(artifact.data || artifact.attachment.name) | fang}}</strong>
+    </div>
+    <div class="panel-body">
+        <dl class="dl-horizontal" ng-if="content.errorMessage">
+            <dt><i class="fa fa-warning"></i>Error:</dt>
+            <dd class="wrap">{{content.errorMessage}}</dd>
+        </dl>
+    </div>
+</div>

--- a/thehive-templates/RecordedFuture_risk_1_0/short.html
+++ b/thehive-templates/RecordedFuture_risk_1_0/short.html
@@ -1,0 +1,3 @@
+<span class="label" ng-repeat="t in content.taxonomies" ng-class="{'info': 'label-info', 'safe': 'label-success', 'suspicious': 'label-warning', 'malicious':'label-danger'}[t.level]">
+    {{t.namespace}}:{{t.predicate}}="{{t.value}}"
+</span>


### PR DESCRIPTION
This pull request adds an analyzer for RecordedFuture. It was requested in #102.

The analyzer queries the RecordedFuture API to pull the risk summary and displays the number of "evidence details" and the risk score within the short view. The level of the score taxonomy depends on the reported "criticallity": 0 safe, 1 info, 2 suspicious, >=3 malicious  
A summary and the "Triggered Risk Rules" is displayed within the long view. A click on the "Intel Card" button will open a new tab with the corresponding intel card within the RecordedFuture web app.

![cortex-analyzer_recordedfuture_short_example](https://user-images.githubusercontent.com/4180675/46204474-ad136f00-c31d-11e8-81cc-8a358655503b.png)
![cortex-analyzer_recordedfuture_long_example](https://user-images.githubusercontent.com/4180675/46204483-b3095000-c31d-11e8-8056-1c2350557b10.png)

![cortex-analyzer_recordedfuture_short_malicious](https://user-images.githubusercontent.com/4180675/46204478-b0a6f600-c31d-11e8-9d4b-e17d68f56638.png)
![cortex-analyzer_recordedfuture_long_malicious](https://user-images.githubusercontent.com/4180675/46204490-b69cd700-c31d-11e8-9bd9-a39d963c9e6d.png)
