### PR TITLE
Fix a typo in URLhaus's long.html

### DIFF
--- a/thehive-templates/URLhaus_1_0/long.html
+++ b/thehive-templates/URLhaus_1_0/long.html
@@ -44,7 +44,7 @@
   <div class="panel-body">
     <dl class="dl-horizontal" ng-if="content.errorMessage">
       <dt>
-        <i class="fa fa-warning"></i> urlscan.io: </dt>
+        <i class="fa fa-warning"></i> URLhaus: </dt>
       <dd class="wrap">{{content.errorMessage}}</dd>
     </dl>
   </div>


### PR DESCRIPTION
I made a typo in URLhaus's report template (long.html). So let me fix it.