### PR TITLE
Fix for Fortiguard to handle FQDNs as well as domains and urls

### DIFF
--- a/analyzers/Fortiguard/Fortiguard_URLCategory.json
+++ b/analyzers/Fortiguard/Fortiguard_URLCategory.json
@@ -4,8 +4,8 @@
   "author": "Eric Capuano",
   "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
   "license": "AGPL-V3",
-  "dataTypeList": ["domain", "url"],
-  "description": "Check the Fortiguard category of a URL or a domain. Check the full available list at https://fortiguard.com/webfilter/categories",
+  "dataTypeList": ["domain", "url", "fqdn"],
+  "description": "Check the Fortiguard category of a URL, FQDN or a domain. Check the full available list at https://fortiguard.com/webfilter/categories",
   "baseConfig": "Fortiguard",
   "command": "Fortiguard/urlcategory.py",
   "configurationItems": [

--- a/analyzers/Fortiguard/urlcategory.py
+++ b/analyzers/Fortiguard/urlcategory.py
@@ -33,7 +33,7 @@ class URLCategoryAnalyzer(Analyzer):
     def run(self):
         Analyzer.run(self)
 
-        if self.data_type == 'domain' or self.data_type == 'url':
+        if self.data_type == 'domain' or self.data_type == 'url' or self.data_type == 'fqdn':
             try:
                 pattern = re.compile("(?:Category: )([\w\s]+)")
                 baseurl = 'https://www.fortiguard.com/webfilter?q='


### PR DESCRIPTION
The fortiguard analzer didn't accept fqdns. This fix changes that.