### PR TITLE
fix in case GSB value is missing

### DIFF
--- a/analyzers/URLhaus/URLhaus.py
+++ b/analyzers/URLhaus/URLhaus.py
@@ -58,7 +58,7 @@ class URLhaus:
                 "link": cols[1].find("a").attrs.get("href"),
                 "status": cols[2].text,
                 "tags": cols[3].text.split(),
-                "gsb": cols[4].text,
-                "reporter": cols[5].text
+                "gsb": cols[4].text if len(cols) > 5 else None,
+                "reporter": cols[5].text if len(cols) > 5 else cols[4].text
             })
         return results


### PR DESCRIPTION
I noticed that GSB value is not retrieved in json causing "index out of range" error.
This fix checks if fields is available, otherwise go ahead.
If this field is not available anymore we can skip it and remove also from template long. I don't find documentation about this.
Online: 
![online](https://user-images.githubusercontent.com/16938405/47560342-3bc4dd00-d918-11e8-8316-11b3633648f0.PNG)

The Hive:
![cortex](https://user-images.githubusercontent.com/16938405/47560345-3cf60a00-d918-11e8-867a-ee568b858fb8.PNG)

Before the fix:
`{
"errorMessage": "Invalid output\nTraceback (most recent call last):\n File \"URLhaus/URLhaus_analyzer.py\", line 50, in <module>\n URLhausAnalyzer().run()\n File \"URLhaus/URLhaus_analyzer.py\", line 23, in run\n 'results': self.search(self.get_data())\n File \"URLhaus/URLhaus_analyzer.py\", line 17, in search\n return URLhaus(indicator).search()\n File \"/opt/Cortex-Analyzers/analyzers/URLhaus/URLhaus.py\", line 42, in search\n return self.parse(res)\n File \"/opt/Cortex-Analyzers/analyzers/URLhaus/URLhaus.py\", line 62, in parse\n \"reporter\": cols[5].text\nIndexError: list index out of range\n",
"input": null,
"success": false,
"artifacts": []
} `
