### PR TITLE
Analyzer/Umbrella & Templates

### DIFF
--- a/analyzers/Umbrella/Umbrella.py
+++ b/analyzers/Umbrella/Umbrella.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+import json
+import requests
+from cortexutils.analyzer import Analyzer
+
+class UmbrellaAnalyzer(Analyzer):
+    def __init__(self):
+        Analyzer.__init__(self)
+        self.service = self.get_param('config.service', None, 'Service parameter is missing')
+        self.api_key = self.get_param('config.api_key', None, 'api_key is missing')
+        self.api_secret = self.get_param('config.api_secret', None, 'api_secret is missing')
+        self.organization_id = self.get_param('config.organization_id', None, 'organization_id is missing')
+        self.query_limit = str(self.get_param('config.query_limit', None, 20))
+
+    def umbrella_runreport(self, destination):
+        base_url = "https://reports.api.umbrella.com/v1/organizations"
+        url = "{}/{}/destinations/{}/activity?limit={}".format(base_url,self.organization_id,destination,self.query_limit)
+        try:
+            r = requests.get(url, auth=(self.api_key, self.api_secret))
+            if r.status_code == 200:
+                return json.loads(r.text)
+            else:
+                self.error('API query failed. Check parameters.')
+        except Exception as e:
+            self.unexpectedError(e)
+
+    def summary(self, raw):
+        taxonomies = []
+
+        if len(raw['requests']) > 0:
+            taxonomies.append(self.build_taxonomy(
+                'info',
+                'Umbrella',
+                'Hits',
+                'True'))
+        else:
+            taxonomies.append(self.build_taxonomy(
+                'info',
+                'Umbrella',
+                'Hits',
+                'False'))
+
+        return {'taxonomies': taxonomies}
+
+
+    def run(self):
+        if self.service == 'get':
+            if self.data_type == 'domain':
+                data = self.get_param('data', None, 'Data is missing')
+                r = self.umbrella_runreport(data)
+                self.report(r)
+            else:
+                self.error('Invalid data type')
+        else:
+            self.error('Invalid service type')
+
+if __name__ == '__main__':
+        UmbrellaAnalyzer().run()

--- a/analyzers/Umbrella/Umbrella_Report.json
+++ b/analyzers/Umbrella/Umbrella_Report.json
@@ -1,0 +1,45 @@
+{
+  "name": "Umbrella_Report",
+  "version": "1.0",
+  "author": "Kyle Parrish",
+  "url": "https://github.com/arnydo/thehive/Cortex-Analyzers",
+  "license": "AGPL-V3",
+  "description": "Query the Umbrella Reporting API for recent DNS queries and their status.",
+  "dataTypeList": ["domain"],
+  "command": "Umbrella/Umbrella.py",
+  "baseConfig": "Umbrella",
+  "config": {
+        "service": "get"
+  },
+  "configurationItems": [
+    {
+        "name": "api_key",
+        "description": "Api Key provided by Umbrella Admin Console.",
+        "type": "string",
+        "multi": false,
+        "required": true
+    },
+    {
+        "name": "api_secret",
+        "description": "Api Secret provided by Umbrella Admin Console.",
+        "type": "string",
+        "multi": false,
+        "required": true
+    },
+    {
+        "name": "organization_id",
+        "description": "Organization ID provided by Umbrella Admin Console.",
+        "type": "string",
+        "multi": false,
+        "required": true
+    },
+    {
+        "name": "query_limit",
+        "description": "Maximum number of results to return.",
+        "type": "number",
+        "multi": false,
+        "required": false,
+        "default": 20
+    }
+  ]
+}

--- a/analyzers/Umbrella/requirements.txt
+++ b/analyzers/Umbrella/requirements.txt
@@ -1,0 +1,2 @@
+requests
+json

--- a/thehive-templates/Umbrella_Report_1_0/long.html
+++ b/thehive-templates/Umbrella_Report_1_0/long.html
@@ -1,0 +1,48 @@
+<!-- Success -->
+<div class="panel panel-info" ng-if="success && content.requests.length > 0">
+    <div class="panel-heading">
+        Umbrella Report
+    </div>
+    <div class="panel-body">
+        <table class="table table-hover">
+            <tr>
+                <th>Internal IP</th>
+                <th>Device/User</th>
+                <th>Action</th>
+                <th>Category</th>
+                <th>Destination</th>
+                <th>Date</th>
+            </tr>
+            <tr ng-repeat="r in content.requests">
+                <td><strong>{{r.internalIp}}</strong></td>
+                <td>{{r.originLabel}}</td>
+                <td>{{r.actionTaken}}</td>
+                <td>{{r.categories}}</td>
+                <td>{{r.destination}}</td>
+                <td>{{r.datetime}}</td>
+            </tr>
+        </table>
+    </div>
+</div>
+
+<div class="panel panel-info" ng-if="success && content.requests.length == 0">
+    <div class="panel-heading">
+        Umbrella Report
+    </div>
+    <div class="panel-body">
+        <b>No recent hits.</b>
+    </div>
+</div>
+
+<!-- General error  -->
+<div class="panel panel-danger" ng-if="!success">
+    <div class="panel-heading">
+        <strong>{{(artifact.data || artifact.attachment.name) | fang}}</strong>
+    </div>
+    <div class="panel-body">
+        <dl class="dl-horizontal" ng-if="content.errorMessage">
+            <dt><i class="fa fa-warning"></i> Umbrella Report: </dt>
+            <dd class="wrap">{{content.errorMessage}}</dd>
+        </dl>
+    </div>
+</div>

--- a/thehive-templates/Umbrella_Report_1_0/short.html
+++ b/thehive-templates/Umbrella_Report_1_0/short.html
@@ -1,0 +1,3 @@
+<span class="label" ng-repeat="t in content.taxonomies" ng-class="{'info': 'label-info', 'safe': 'label-success', 'suspicious': 'label-warning', 'malicious':'label-danger'}[t.level]">
+    {{t.namespace}}:{{t.predicate}}="{{t.value}}"
+</span>


### PR DESCRIPTION
Umbrella Analyzer currently supports pulling a list of most recent "hits" on a specified domain.
Analyzer utilizes the [Cisco Umbrella Reporting API](https://docs.umbrella.com/umbrella-api/docs/reporting-destinations-most-recent-requests).

Address issue #385 