### PR TITLE
fix the lack of dependency called enum in ubuntu 16.04

### DIFF
--- a/analyzers/MISP/requirements.txt
+++ b/analyzers/MISP/requirements.txt
@@ -1,3 +1,4 @@
 cortexutils
 pymisp
+enum
 future;python_version<='2.7'


### PR DESCRIPTION
MISP analyzer will not work properly without enum package
It's not a built-in package in ubuntu