### PR TITLE
Updating Cuckoo Analyzer/Report Templates

### DIFF
--- a/analyzers/CuckooSandbox/cuckoosandbox_analyzer.py
+++ b/analyzers/CuckooSandbox/cuckoosandbox_analyzer.py
@@ -105,17 +105,17 @@ class CuckooSandboxAnalyzer(Analyzer):
             else:
                 snort_alerts = []
             try:
-                hosts = [(x['ip'], x['hostname'], x['country_name']) for x in
-                         resp_json['network']['hosts']] if 'hosts' in resp_json['network'].keys() else None
+                domains = [(x['ip'], x['domain']) for x in
+                         resp_json['network']['domains']] if 'domains' in resp_json['network'].keys() else None
             except TypeError as e:
-                hosts = [x for x in resp_json['network']['hosts']] if 'hosts' in resp_json['network'].keys() else []
+                domains = [x for x in resp_json['network']['domains']] if 'domains' in resp_json['network'].keys() else []
             uri = [(x['uri']) for x in resp_json['network']['http']] if 'http' in resp_json['network'].keys() else []
             if self.data_type == 'url':
                 self.report({
                     'signatures': list_description,
                     'suricata_alerts': suri_alerts,
                     'snort_alerts': snort_alerts,
-                    'hosts': hosts,
+                    'domains': domains,
                     'uri': uri,
                     'malscore': resp_json['malscore'] if 'malscore' in resp_json.keys() else resp_json['info'].get(
                         'score', None),
@@ -129,7 +129,7 @@ class CuckooSandboxAnalyzer(Analyzer):
                     'signatures': list_description,
                     'suricata_alerts': suri_alerts,
                     'snort_alerts': snort_alerts,
-                    'hosts': hosts,
+                    'domains': domains,
                     'uri': uri,
                     'malscore': resp_json['malscore'] if 'malscore' in resp_json.keys() else resp_json['info'].get(
                         'score', None),

--- a/thehive-templates/CuckooSandbox_File_Analysis_Inet_1_0/long.html
+++ b/thehive-templates/CuckooSandbox_File_Analysis_Inet_1_0/long.html
@@ -59,20 +59,18 @@
         </div>
         <div class="panel-body">
 
-            <div ng-if="content.hosts">
+            <div ng-if="content.domains">
                 <h4>Remote connections</h4>
                 <br>
                 <div>
                     <table class="table table-hover">
                         <tr>
-                            <th>Domain</th>
                             <th>IP</th>
-                            <th>Location</th>
+                            <th>Domain</th>
                         </tr>
-                        <tr ng-repeat="host in content.hosts track by $index">
-                            <td>{{host[1]}}</td>
-                            <td>{{host[0]}}</td>
-                            <td>{{host[2]}}</td>
+                        <tr ng-repeat="domains in content.domains track by $index">
+                            <td>{{domains[0]}}</td>
+                            <td>{{domains[1]}}</td>
                         </tr>
                     </table>
                 </div>
@@ -105,8 +103,8 @@
             <div ng-if="content.yara">
                 <h4>Yara</h4>
                 <br>
-                <dl class="dl-horizontal" ng-repeat="yara in content.yara track by $index">
-                    <dd>{{ yara }}<dd>
+                <dl class="dl-horizontal">
+                    <dd>{{ content.yara }}<dd>
                 </dl>
             </div>
             <div ng-if="!content.yara">

--- a/thehive-templates/CuckooSandbox_Url_Analysis_1_0/long.html
+++ b/thehive-templates/CuckooSandbox_Url_Analysis_1_0/long.html
@@ -59,20 +59,18 @@
         </div>
         <div class="panel-body">
 
-            <div ng-if="content.hosts">
+            <div ng-if="content.domains">
                 <h4>Remote connections</h4>
                 <br>
                 <div>
                     <table class="table table-hover">
                         <tr>
-                            <th>Domain</th>
                             <th>IP</th>
-                            <th>Location</th>
+                            <th>Domain</th>
                         </tr>
-                        <tr ng-repeat="host in content.hosts track by $index">
-                            <td>{{host[1]}}</td>
-                            <td>{{host[0]}}</td>
-                            <td>{{host[2]}}</td>
+                        <tr ng-repeat="domains in content.domains track by $index">
+                            <td>{{domains[0]}}</td>
+                            <td>{{domains[1]}}</td>
                         </tr>
                     </table>
                 </div>


### PR DESCRIPTION
### Request Type
Analyzer

### Work Environment
N/A

| Question              | Answer
|---------------------------|--------------------
| OS version (server)       | Ubuntu
| Cortex Analyzer Name      | CuckooSandbox Analyzer
| Cortex Analyzer Version   | 1.0
| Cortex Version            |  2.1.3-1


### Description
The current Cuckoo Sandbox reports do not fully function with 2.0.6 Cuckoo Reports. Instead of using just hosts for the report data, we need to use domains to retrieve ip/domain combination.

### Possible Solutions
The solution is to update the analyzer and report templates to properly show the report data.

### Complementary information
I have a fix for the solution however it would also then be nice to extract the observables from the newly added ip/domain combinations.

Here is what a report currently looks with Cuckoo 2.0.6:
![image](https://user-images.githubusercontent.com/5582679/52279503-4df2e600-291f-11e9-820e-5055884639d3.png)

And this is after the analyzer and report fix:
![image](https://user-images.githubusercontent.com/5582679/52280542-c490e300-2921-11e9-970b-6ad702f9213a.png)

