### PR TITLE
Responder QRadarAutoClose

### DIFF
--- a/responders/QRadarAutoClose/QRadarAutoClose.json
+++ b/responders/QRadarAutoClose/QRadarAutoClose.json
@@ -1,0 +1,34 @@
+{
+  "name": "QRadar Auto Closing Offense",
+  "version": "1.0",
+  "author": "Florian Perret",
+  "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
+  "license": "AGPL-V3",
+  "description": "Closing the QRadar Offense associated to your case in one clic !",
+  "dataTypeList": ["thehive:case"],
+  "command": "QRadarAutoClose/QRadarAutoClose.py",
+  "baseConfig": "QRadarAutoClose",
+  "configurationItems": [
+    {
+      "name": "QRadar_API_Key",
+      "description": "A QRadar API key with sufficent rights to close an offense",
+      "type": "string",
+      "multi": false,
+      "required": true
+    },
+    {
+      "name": "QRadar_Url",
+      "description": "URL of your QRadar API, must be accessible from Cortex server. eg: myqradar.myorg.com/api/siem/offenses",
+      "type": "string",
+      "multi": false,
+      "required": true
+    },
+    {
+      "name": "Cert_Path",
+      "description": "If you need a certificate to authentificate to your QRadar API, please provide the path here",
+      "type": "string",
+      "multi": false,
+      "required": false
+    }
+  ]
+}

--- a/responders/QRadarAutoClose/QRadarAutoClose.py
+++ b/responders/QRadarAutoClose/QRadarAutoClose.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
-#QRadarAutoClose
-#Author: Florian Perret (@cyber_pescadito)
+# QRadarAutoClose
+# Author: Florian Perret (@cyber_pescadito)
 
 from cortexutils.responder import Responder
 import requests
+
 
 class QRadarAutoClose(Responder):
     def __init__(self):
@@ -13,24 +14,28 @@ class QRadarAutoClose(Responder):
         self.QRadar_URL = self.get_param('config.QRadar_Url', None, "QRadar URL is Missing")
         self.QRadar_API_Key = self.get_param('config.QRadar_API_Key', None, "QRadar API Key is Missing")
         self.Offense_Id = self.get_param('data.customFields.externalReferences', None, "QRadar Offense ID is Missing")
-	self.Cert_Path = self.get_param('config.Cert_Path')
+        self.Cert_Path = self.get_param('config.Cert_Path')
 
     def run(self):
-    	Responder.run(self)
-    	h = {'content-type': 'application/json'}
-    	h['Version'] = '9.1'
-    	h['SEC'] = str(self.QRadar_API_Key)
-    	payload = self.Offense_Id['string'] + '?closing_reason_id=3&status=CLOSED'
+        h = {
+            'content-type': 'application/json',
+            'Version': '9.1',
+            'SEC': str(self.QRadar_API_Key)
+        }
+        payload = self.Offense_Id['string'] + '?closing_reason_id=3&status=CLOSED'
 
-	if self.Cert_Path == '':
-		r=requests.post(self.QRadar_URL + payload, headers=h)
+        if self.Cert_Path == '':
+            r = requests.post(self.QRadar_URL + payload, headers=h)
         else:
-		r=requests.post(self.QRadar_URL + payload, headers=h, verify=self.Cert_Path)
+            r = requests.post(self.QRadar_URL + payload, headers=h, verify=self.Cert_Path)
 
-	if r.status_code == 200 or 202 or 409:
-        	self.report({'message': 'QRadar Offense succesfully closed !'})
+        if r.status_code == 200 or \
+                r.status_code == 202 or \
+                r.status_code == 409:
+            self.report({'message': 'QRadar Offense succesfully closed !'})
         else:
-        	self.error({'message': r.status_code})
+            self.error({'message': r.status_code})
+
 
 if __name__ == '__main__':
-        QRadarAutoClose().run()
+    QRadarAutoClose().run()

--- a/responders/QRadarAutoClose/QRadarAutoClose.py
+++ b/responders/QRadarAutoClose/QRadarAutoClose.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# encoding: utf-8
+
+#QRadarAutoClose
+#Author: Florian Perret (@cyber_pescadito)
+
+from cortexutils.responder import Responder
+import requests
+
+class QRadarAutoClose(Responder):
+    def __init__(self):
+        Responder.__init__(self)
+        self.QRadar_URL = self.get_param('config.QRadar_Url', None, "QRadar URL is Missing")
+        self.QRadar_API_Key = self.get_param('config.QRadar_API_Key', None, "QRadar API Key is Missing")
+        self.Offense_Id = self.get_param('data.customFields.externalReferences', None, "QRadar Offense ID is Missing")
+	self.Cert_Path = self.get_param('config.Cert_Path')
+
+    def run(self):
+    	Responder.run(self)
+    	h = {'content-type': 'application/json'}
+    	h['Version'] = '9.1'
+    	h['SEC'] = str(self.QRadar_API_Key)
+    	payload = self.Offense_Id['string'] + '?closing_reason_id=3&status=CLOSED'
+
+	if self.Cert_Path == '':
+		r=requests.post(self.QRadar_URL + payload, headers=h)
+        else:
+		r=requests.post(self.QRadar_URL + payload, headers=h, verify=self.Cert_Path)
+
+	if r.status_code == 200 or 202 or 409:
+        	self.report({'message': 'QRadar Offense succesfully closed !'})
+        else:
+        	self.error({'message': r.status_code})
+
+if __name__ == '__main__':
+        QRadarAutoClose().run()

--- a/responders/QRadarAutoClose/README.md
+++ b/responders/QRadarAutoClose/README.md
@@ -1,0 +1,2 @@
+If you need to change the customfield which contain the QRadar Offense ID, change the "externalReferences" from QRadarAutoClose.py line 15.
+Be careful this have to be fulfill with the "Internal Reference" of the customfield, not it's name !

--- a/responders/QRadarAutoClose/README.md
+++ b/responders/QRadarAutoClose/README.md
@@ -1,2 +1,4 @@
+Simple responder to close a QRadar Offense through a simple clic !
+
 If you need to change the customfield which contain the QRadar Offense ID, change the "externalReferences" from QRadarAutoClose.py line 15.
 Be careful this have to be fulfill with the "Internal Reference" of the customfield, not it's name !

--- a/responders/QRadarAutoClose/requirements.txt
+++ b/responders/QRadarAutoClose/requirements.txt
@@ -1,4 +1,2 @@
-reponders/QRadarAutoClose
-|--QRadarAutoClose.json
-|--requirements.txt
-`--QradarAutoClose.py
+cortexutils.responder
+requests

--- a/responders/QRadarAutoClose/requirements.txt
+++ b/responders/QRadarAutoClose/requirements.txt
@@ -1,0 +1,4 @@
+reponders/QRadarAutoClose
+|--QRadarAutoClose.json
+|--requirements.txt
+`--QradarAutoClose.py

--- a/responders/QRadarAutoClose/requirements.txt
+++ b/responders/QRadarAutoClose/requirements.txt
@@ -1,2 +1,2 @@
-cortexutils.responder
+cortexutils
 requests


### PR DESCRIPTION
Hi,

I want to share with you a responder that i wrote in python. He is working on my hive platform so I believe it's ready to use.

The main purpose of this responder is to close in one clic a QRadar offense from a TheHive case.

How it works:

Installation and configuration:
-Intall it in your Cortex Analyzers folder, in the responder section
-On Cortex WebUI, configure your QRadar console URL, an API key (service token), and a certificate if needed.

Use It:
-On TheHive, provide to your case the related QRadar offense ID in a customfield "externalReferences" (this have to be the customfield Internal Reference). I recommend to automatically fulfill via script this customfield when importing offenses as alert
-Clic the responder, and it will automagically close the offense in QRadar. That's all :-)

FR: https://github.com/TheHive-Project/Cortex-Analyzers/issues/441

Happy threat hunting ;-)