### PR TITLE
Abuse_Finder : Add support to Python3.6

### DIFF
--- a/analyzers/Abuse_Finder/requirements.txt
+++ b/analyzers/Abuse_Finder/requirements.txt
@@ -1,2 +1,2 @@
 cortexutils
-abuse_finder;python_version<='2.7'
+abuse_finder


### PR DESCRIPTION
This change is not enough (of course), it needs this PR to be merged :
https://github.com/certsocietegenerale/abuse_finder/pull/3