### PR TITLE
fix when hash not found

### DIFF
--- a/analyzers/URLhaus/URLhaus_analyzer.py
+++ b/analyzers/URLhaus/URLhaus_analyzer.py
@@ -34,7 +34,8 @@ class URLhausAnalyzer(Analyzer):
         taxonomies = []
         namespace = "URLhaus"
 
-        if raw['query_status'] == 'no_results':
+        if raw['query_status'] == 'no_results' \
+        or raw['query_status'] == 'ok' and raw['md5_hash'] == None and raw['sha256_hash'] == None:
             taxonomies.append(self.build_taxonomy(
                 'info',
                 namespace,


### PR DESCRIPTION
Fix when hash not found, due to an unexpected return from urlhaus.
In this example the hash is not found but api returns ok:

![immagine](https://user-images.githubusercontent.com/16938405/58545096-dbc24c00-8202-11e9-99ae-689a74c24439.png)

Then in the short report the label is wrong:
![immagine](https://user-images.githubusercontent.com/16938405/58545222-1cba6080-8203-11e9-83da-49c4c4b85ccc.png)



Now returns the expected behavior:
![immagine](https://user-images.githubusercontent.com/16938405/58550000-18934080-820d-11e9-89a3-a33763f9cc71.png)
