### PR TITLE
Fix category parsing forom Fortiguard URLCategory

### DIFF
--- a/analyzers/Fortiguard/urlcategory.py
+++ b/analyzers/Fortiguard/urlcategory.py
@@ -35,7 +35,7 @@ class URLCategoryAnalyzer(Analyzer):
 
         if self.data_type == 'domain' or self.data_type == 'url' or self.data_type == 'fqdn':
             try:
-                pattern = re.compile("(?:Category: )([\w\s]+)")
+                pattern = re.compile("(?:Category: )([-\w\s]+)")
                 baseurl = 'https://www.fortiguard.com/webfilter?q='
                 url = baseurl + self.get_data()
                 req = requests.get(url)


### PR DESCRIPTION
This PR addresses the issue #493 by handling "-" as a possible character in the categories names