### PR TITLE
removed python builtins from requirements.txt

### DIFF
--- a/responders/FalconCustomIOC/requirements.txt
+++ b/responders/FalconCustomIOC/requirements.txt
@@ -1,4 +1,1 @@
-json
-re
 requests
-traceback


### PR DESCRIPTION
Removed python builtins from `responders/FalconCustomIOC/requirements.txt`. These throw error messages during install with `pip install -U -r requirements.txt`.

Fix for issue 509