### PR TITLE
[ThreatCrowd ] Fixing Unexpected Error: get() takes exactly 1 argument (2 given)

### DIFF
--- a/analyzers/Threatcrowd/threatcrowd_analyzer.py
+++ b/analyzers/Threatcrowd/threatcrowd_analyzer.py
@@ -42,7 +42,7 @@ class Threatcrowd(Analyzer):
             threatcrowd_data_type = self.data_type if self.data_type != 'mail' else 'email'
             try:
                 response = requests.get("{}/{}/report/".format(self.URI, threatcrowd_data_type),
-                                        {threatcrowd_data_type: self.get_data()})
+                                        params = {threatcrowd_data_type: self.get_data()})
                 self.report(response.json())
             except Exception as e:
                 self.unexpectedError(e)


### PR DESCRIPTION
Hi,

ThreatCrowd analyzer was not working for me... 
requests.get was complaining about - _get() takes exactly 1 argument (2 given)_, because "params" was missing. 

Hope this PR was done in the right manner, because it's my first ever PR.

Let me know if I did something wrong.