### PR TITLE
Csoauth2

### DIFF
--- a/responders/FalconCustomIOC/FalconAuth.py
+++ b/responders/FalconCustomIOC/FalconAuth.py
@@ -1,0 +1,33 @@
+import time
+import json
+import requests
+
+
+class FalconAuth:
+    def __init__(self, client_id, client_secret):
+        self.client_id = client_id
+        self.client_secret = client_secret
+        with open("/tmp/OAuth2.json", "w+") as f:
+            f.write("")
+
+    def newtoken(self):
+        response = requests.post("https://api.crowdstrike.com/oauth2/token", data={"client_id": self.client_id, "client_secret": self.client_secret},
+                                 headers={"Content-Type": "application/x-www-form-urlencoded", "Accept": "application/json"})
+        if not response.status_code == 201:
+            return None
+        json_data = response.json()
+        json_data["expires"] = time.time()+json_data["expires_in"]
+        return json_data
+
+    def getToken(self):
+        tokendata = ''
+        with open("/tmp/OAuth2.json", "r") as f:
+            try:
+                tokendata = json.loads(f.read())
+                if tokendata['expires'] < time.time()+1.0:
+                    tokendata = self.newtoken()
+            except Exception:
+                tokendata = self.newtoken()
+        with open("/tmp/OAuth2.json", "w+") as f:
+            f.write(json.dumps(tokendata))
+            return tokendata['access_token']

--- a/responders/FalconCustomIOC/FalconCustomIOC.json
+++ b/responders/FalconCustomIOC/FalconCustomIOC.json
@@ -1,34 +1,34 @@
 {
-  "name": "Crowdstrike Falcon Custom IOC API",
-  "version": "1.0",
-  "author": "Michael",
-  "url": "https://www.crowdstrike.com/blog/tech-center/import-iocs-crowdstrike-falcon-host-platform-via-api/",
-  "license": "MIT",
-  "description": "Submit observables to the Crowdstrike Falcon Custom IOC api",
-  "dataTypeList": ["thehive:alert","thehive:case_artifact"],
-  "command": "FalconCustomIOC/FalconCustomIOC.py",
-  "baseConfig": "FalconCustomIOC",
-  "configurationItems": [
-    {
-      "name": "falconapi_url",
-      "description": "Crowdstrike Falcon host url",
-      "type": "string",
-      "multi": false,
-      "required": true
-    },
-    {
-      "name": "falconapi_user",
-      "description": "Crowdstrike Falcon query api user",
-      "type": "string",
-      "multi": false,
-      "required": true
-    },
-    {
-      "name": "falconapi_key",
-      "description": "Crowdstrike Falcon query api key",
-      "type": "string",
-      "multi": false,
-      "required": true
-    }
-  ]
+    "name": "Crowdstrike Falcon Custom IOC API",
+    "version": "1.0",
+    "author": "Michael",
+    "url": "https://www.crowdstrike.com/blog/tech-center/import-iocs-crowdstrike-falcon-host-platform-via-api/",
+    "license": "MIT",
+    "description": "Submit observables to the Crowdstrike Falcon Custom IOC api",
+    "dataTypeList": ["thehive:alert", "thehive:case_artifact"],
+    "command": "FalconCustomIOC/FalconCustomIOC.py",
+    "baseConfig": "FalconCustomIOC",
+    "configurationItems": [
+        {
+            "name": "falconapi_url",
+            "description": "Crowdstrike Falcon host url",
+            "type": "string",
+            "multi": false,
+            "required": true
+        },
+        {
+            "name": "falconapi_user",
+            "description": "Crowdstrike Falcon query api user",
+            "type": "string",
+            "multi": false,
+            "required": true
+        },
+        {
+            "name": "falconapi_key",
+            "description": "Crowdstrike Falcon query api key",
+            "type": "string",
+            "multi": false,
+            "required": true
+        }
+    ]
 }

--- a/responders/FalconCustomIOC/FalconCustomIOC.py
+++ b/responders/FalconCustomIOC/FalconCustomIOC.py
@@ -13,8 +13,6 @@ from requests.auth import HTTPBasicAuth
 class FalconCustomIOC(Responder):
     def __init__(self):
         Responder.__init__(self)
-        with open("/tmp/dbx", "w+") as f:
-            f.write(json.dumps(self._input, sort_keys=True, indent=4))
         self.falconapi_url = "https://falconapi.crowdstrike.com/indicators/entities/iocs/v1"
         self.apiuser = self.get_param(
             'config.falconapi_user', None, "Falcon query api key missing")

--- a/responders/FalconCustomIOC/FalconCustomIOCv2.json
+++ b/responders/FalconCustomIOC/FalconCustomIOCv2.json
@@ -1,0 +1,27 @@
+{
+    "name": "Crowdstrike Falcon Custom IOC API OAUTH2",
+    "version": "2.0",
+    "author": "Michael G. (github.com/ag-michael)",
+    "url": "https://www.crowdstrike.com/blog/tech-center/import-iocs-crowdstrike-falcon-host-platform-via-api/",
+    "license": "MIT",
+    "description": "Submit observables to the Crowdstrike Falcon Custom IOC api",
+    "dataTypeList": ["thehive:alert", "thehive:case_artifact"],
+    "command": "FalconCustomIOC/FalconCustomIOCv2.py",
+    "baseConfig": "FalconCustomIOCv2",
+    "configurationItems": [
+        {
+            "name": "clientid",
+            "description": "Crowdstrike Falcon API oauth2 client id",
+            "type": "string",
+            "multi": false,
+            "required": true
+        },
+        {
+            "name": "clientsecret",
+            "description": "Crowdstrike Falcon API oauth2 secret",
+            "type": "string",
+            "multi": false,
+            "required": true
+        }
+    ]
+}

--- a/responders/FalconCustomIOC/FalconCustomIOCv2.py
+++ b/responders/FalconCustomIOC/FalconCustomIOCv2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 
 import requests
@@ -8,48 +8,58 @@ import traceback
 
 from cortexutils.responder import Responder
 from requests.auth import HTTPBasicAuth
+from FalconAuth import FalconAuth
+
+
+def cortexinputbug():
+    import sys
+    if len(sys.argv) > 1:
+        try:
+            sys.stdin = open(sys.argv[1]+"/input/input.json")
+        except:
+            with open("/tmp/responder_error", "w+") as e:
+                e.write(traceback.format_exc())
 
 
 class FalconCustomIOC(Responder):
     def __init__(self):
         Responder.__init__(self)
-        with open("/tmp/dbx", "w+") as f:
-            f.write(json.dumps(self._input, sort_keys=True, indent=4))
-        self.falconapi_url = "https://falconapi.crowdstrike.com/indicators/entities/iocs/v1"
-        self.apiuser = self.get_param(
-            'config.falconapi_user', None, "Falcon query api key missing")
-        self.apikey = self.get_param(
-            'config.falconapi_key', None, "Falcon query api key missing")
+        self.falconapi_url = "https://api.crowdstrike.com/indicators/entities/iocs/v1"
+        self.clientid = self.get_param(
+            'config.clientid', None, "Crowdstrike API oauth2 client id missing")
+        self.clientsecret = self.get_param(
+            'config.clientsecret', None, "Crowdstrike API oauth2 client secret missing")
+        self.auth = FalconAuth(self.clientid, self.clientsecret)
 
     def run(self):
         try:
             Responder.run(self)
-            ioctypes = {"hash": "sha256", "sha256": "sha256", "md5": "md5", "sha1": "sha1",
-                        "ip": "ipv4", "ip6": "ipv6", "ipv6": "ipv6", "domain": "domain", "url": "domain"}
+            ioctypes = {"hash": u"sha256", "sha256": u"sha256", "md5": u"md5", "sha1": u"sha1",
+                        "ip": u"ipv4", "ip6": u"ipv6", "ipv6": u"ipv6", "domain": u"domain", "url": u"domain"}
             data_type = self.get_param('data.dataType')
             if not data_type in ioctypes:
                 self.error("Unsupported IOC type")
-                return
+                raise
             ioc = self.get_param('data.data', None, 'No IOC provided')
             if data_type == "url":
                 match = re.match(
                     r"(http:\/\/|https:\/\/)?([\w\d\-\.]{0,256}).*", ioc)
                 if match is None or match.group(2) is None:
                     self.error("Could not parse domain from URL")
-                    return
+                    raise
                 else:
                     ioc = match.group(2)
             description = self.get_param(
                 'data.case.title', None, "Can't get case title")
-            description = str(description).encode('utf-8')[:128]
-            postdata = json.dumps([{"type": ioctypes[data_type], "value": ioc.strip(), "policy": "detect", "description": description,
-                                    "share_level": "red", "source": "Cortex - FalconCustomIOC ["+description+"]", "expiration_days": 30}])
+            description = u"{}".format(description.encode('utf-8')[:128])
+            postdata = json.dumps([{"type": ioctypes[data_type], "value": ioc.strip(), "policy": u"detect", "description": description,
+                                    "share_level": u"red", "source": u"Cortex - FalconCustomIOC [{}]".format(description), "expiration_days": 30}])
             response = requests.post(self.falconapi_url, data=postdata, headers={
-                                     "Content-Type": "application/json"}, auth=HTTPBasicAuth(self.apiuser, self.apikey))
+                                     "Content-Type": "application/json", "Authorization": "Bearer {}".format(self.auth.getToken())})
             json_response = json.loads(response.text)
             if json_response["errors"]:
                 self.error(str(json_response["errors"]))
-                return
+                raise
             else:
                 self.report(
                     {'message': ioc+" Submitted to Crowdstrike Falcon custom IOC api", "api_response": json_response})
@@ -61,4 +71,5 @@ class FalconCustomIOC(Responder):
 
 
 if __name__ == '__main__':
+    cortexinputbug()
     FalconCustomIOC().run()

--- a/responders/FalconCustomIOC/requirements.txt
+++ b/responders/FalconCustomIOC/requirements.txt
@@ -1,4 +1,1 @@
-json
-re
 requests
-traceback


### PR DESCRIPTION
Crowdstrike has changed how their API authentication works, they are now using OAUTH2 and have deprecated the legacy authentication API. 

I have added a new responder `Crowdstrike Falcon Custom IOC API OAUTH2_2_0`  which runs on python3 (old responder was python2). 

While creating this, with the latest cortexutils I ran into a bug where the responder (via cortexutils) was expecting input from stdin but cortex was saving it to /tmp/<job folder>/input/input/json: 
https://github.com/TheHive-Project/Cortex/blob/13ecd332cd63becdc98b470ae989425b3feb7a43/app/org/thp/cortex/services/JobRunnerSrv.scala#L93

The new responder 'remaps' stdin to this file:

```
def cortexinputbug():
    import sys
    if len(sys.argv) > 1:
        try:
            sys.stdin = open(sys.argv[1]+"/input/input.json")
        except:
            with open("/tmp/responder_error", "w+") as e:
                e.write(traceback.format_exc())
```
please feel free to remove this work around if the bug in cortexutils has been fixed. 
