### PR TITLE
 DomainTools Iris - Risky DNS Responder

### DIFF
--- a/responders/DomainToolsIris_AddRiskyDNSTag/DomainToolsIris_AddRiskyDNSTag.json
+++ b/responders/DomainToolsIris_AddRiskyDNSTag/DomainToolsIris_AddRiskyDNSTag.json
@@ -1,0 +1,28 @@
+{
+  "name": "DomainToolsIris_AddRiskyDNSTag",
+  "version": "1.0",
+  "author": "DomainTools",
+  "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
+  "license": "AGPL-V3",
+  "description": "Add Tag saying that the case contains a risky DNS.",
+  "dataTypeList": ["thehive:case_artifact"],
+  "command": "DomainToolsIris_AddRiskyDNSTag/domaintoolsiris_responder.py",
+  "baseConfig": "DomainToolsIris",
+  "configurationItems": [
+    {
+      "name": "high_risk_threshold",
+      "description": "Risk score threshold to be considered high risk.",
+      "type": "number",
+      "multi": false,
+      "required": false,
+      "defaultValue": 70
+    },
+    {
+      "name": "monitored_iris_tags",
+      "description": "Monitored Iris tags.",
+      "type": "string",
+      "multi": true,
+      "required": false
+    }
+  ]
+}

--- a/responders/DomainToolsIris_AddRiskyDNSTag/domaintoolsiris_responder.py
+++ b/responders/DomainToolsIris_AddRiskyDNSTag/domaintoolsiris_responder.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
+
+from cortexutils.responder import Responder
+
+
+class DomainToolsIris(Responder):
+    def __init__(self):
+        Responder.__init__(self)
+
+    def run(self):
+        Responder.run(self)
+        if self.get_param("data.dataType") == "domain":
+            self.report({"data": self.get_data()})
+        else:
+            self.report({"data": 'Can only operate on "domain" observables'})
+
+    def operations(self, raw):
+        build_list = []
+        taxonomies = (
+            raw.get("data", {})
+            .get("reports", {})
+            .get("DomainToolsIris_Investigate_1_0", {})
+            .get("taxonomies", None)
+        )
+
+        for x in taxonomies:
+            if x["predicate"] == "Risk Score":
+                if int(x["value"]) > int(self.get_param("config.high_risk_threshold")):
+                    build_list.append(
+                        self.build_operation("AddTagToCase", tag="DT:Risky DNS")
+                    )
+                    build_list.append(
+                        self.build_operation("AddTagToArtifact", tag="DT:Risky DNS")
+                    )
+        return build_list
+
+
+if __name__ == "__main__":
+    DomainToolsIris().run()


### PR DESCRIPTION
DomainTools add risky DNS tag to artifact and case depending on risk score tag from DomainTools.