### PR TITLE
 DomainTools Iris - Malicious Tags Responder

### DIFF
--- a/responders/DomainToolsIris_CheckMaliciousTags/DomainToolsIris_CheckMaliciousTags.json
+++ b/responders/DomainToolsIris_CheckMaliciousTags/DomainToolsIris_CheckMaliciousTags.json
@@ -1,0 +1,28 @@
+{
+  "name": "DomainToolsIris_CheckMaliciousTags",
+  "version": "1.0",
+  "author": "DomainTools",
+  "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
+  "license": "AGPL-V3",
+  "description": "Add Tag saying that the observable and case have a malicious tag in their Iris Tags.",
+  "dataTypeList": ["thehive:case_artifact"],
+  "command": "DomainToolsIris_CheckMaliciousTags/domaintoolsiris_responder.py",
+  "baseConfig": "DomainToolsIris",
+  "configurationItems": [
+    {
+      "name": "high_risk_threshold",
+      "description": "Risk score threshold to be considered high risk.",
+      "type": "number",
+      "multi": false,
+      "required": false,
+      "defaultValue": 70
+    },
+    {
+      "name": "monitored_iris_tags",
+      "description": "Monitored Iris tags.",
+      "type": "string",
+      "multi": true,
+      "required": false
+    }
+  ]
+}

--- a/responders/DomainToolsIris_CheckMaliciousTags/domaintoolsiris_responder.py
+++ b/responders/DomainToolsIris_CheckMaliciousTags/domaintoolsiris_responder.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
+
+from cortexutils.responder import Responder
+
+
+class DomainToolsIris(Responder):
+    def __init__(self):
+        Responder.__init__(self)
+
+    def run(self):
+        Responder.run(self)
+        if self.get_param("data.dataType") == "domain":
+            self.report({"data": self.get_data()})
+        else:
+            self.report({"data": 'Can only operate on "domain" observables'})
+
+    def operations(self, raw):
+        build_list = []
+        taxonomies = (
+            raw.get("data", {})
+            .get("reports", {})
+            .get("DomainToolsIris_Investigate_1_0", {})
+            .get("taxonomies", None)
+        )
+
+        for x in taxonomies:
+            if x["predicate"] == "IrisTags":
+                malicious_tags_set = set(self.get_param("config.monitored_iris_tags"))
+                domain_tags_set = set(x["value"].split(","))
+
+                if len(malicious_tags_set.intersection(domain_tags_set)):
+                    build_list.append(
+                        self.build_operation(
+                            "AddTagToArtifact", tag="DT:Malicious Domain"
+                        )
+                    )
+                    build_list.append(
+                        self.build_operation("AddTagToCase", tag="DT:Malicious Domain")
+                    )
+        return build_list
+
+
+if __name__ == "__main__":
+    DomainToolsIris().run()


### PR DESCRIPTION
DomainTools check for malicious tags depending on iris tags from DomainTools and add a tag to artifact and case.