### PR TITLE
Abuse_Finder Dockerize

### DIFF
--- a/analyzers/Abuse_Finder/Abuse_Finder.json
+++ b/analyzers/Abuse_Finder/Abuse_Finder.json
@@ -1,6 +1,6 @@
 {
   "name": "Abuse_Finder",
-  "version": "3.0",
+  "version": "3.0.0",
   "author": "CERT-BDF",
   "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
   "license": "AGPL-V3",

--- a/analyzers/Abuse_Finder/Dockerfile
+++ b/analyzers/Abuse_Finder/Dockerfile
@@ -1,6 +1,19 @@
-FROM python:3.6
+FROM python:3-alpine
+
+LABEL author="CERT-BDF" \
+      description="Find abuse contacts associated with domain names, URLs, IPs and email addresses." \
+      license="AGPL-V3" \
+      source="https://github.com/TheHive-Project/Cortex-Analyzers" \
+      title="Abuse_Finder" \
+      url="https://github.com/TheHive-Project/Cortex-Analyzers" \
+      vendor="TheHive" \
+      version="3.0.0"
 
 WORKDIR /worker
+
 COPY . Abuse_Finder
-RUN pip3 install --no-cache-dir -r Abuse_Finder/requirements.txt
+
+# Project determined to be Python, installing deps
+RUN pip install --no-cache-dir -r Abuse_Finder/requirements.txt
+
 ENTRYPOINT Abuse_Finder/abusefinder.py

--- a/analyzers/Abuse_Finder/requirements.txt
+++ b/analyzers/Abuse_Finder/requirements.txt
@@ -1,3 +1,4 @@
 cortexutils
 abuse_finder
 future
+pythonwhois==2.2.2


### PR DESCRIPTION
# Abuse_Finder Dockerize

### Changes
1. semver convention
1. base image `python:3.6` => `python:3-alpine`
1. `LABEL` metadata tags
1. Freezing `pythonwhois` at version 2.2.2 as is known that [this dependency tree is broken](https://github.com/joepie91/python-whois/issues/151#issuecomment-530801921)