### PR TITLE
Fix bug emlparser when 'content-type' string in mail is in lower case

### DIFF
--- a/analyzers/EmlParser/parse.py
+++ b/analyzers/EmlParser/parse.py
@@ -68,7 +68,7 @@ def parseEml(filepath):
     #splited string because it was returning the body inside 'Content-Type'
     hParser = email.parser.HeaderParser()
     h = str(hParser.parsestr(raw_eml))
-    result['headers'] = h[:h.index('Content-Type:')]
+    result['headers'] = h[:h.lower().index('content-type:')]
 
     parsed_eml = eml_parser.eml_parser.decode_email(filepath, include_raw_body=True, include_attachment_data=True)
     #parsed_eml['header'].keys() gives:


### PR DESCRIPTION
Emlparser crashes when the string "Content-Type" is not found. In some cases it's available as "Content-type" or "content-type" , this fixes those cases