### PR TITLE
Fix bug in PhisTank analyzer. JSON was loading bytes instead of string.

### DIFF
--- a/analyzers/PhishTank/phishtank_checkurl.py
+++ b/analyzers/PhishTank/phishtank_checkurl.py
@@ -16,7 +16,7 @@ class PhishtankAnalyzer(Analyzer):
         url = 'https://checkurl.phishtank.com/checkurl/'
         postdata = {'url': data, 'format': 'json', 'app_key': self.phishtank_key}
         r = requests.post(url, data=postdata)
-        return json.loads(r.content)
+        return json.loads(r.text)
 
     def summary(self, raw):
         taxonomies = []


### PR DESCRIPTION
A TypeError exception is raised when the analyzer is run.

`TypeError: the JSON object must be str, not 'bytes'`

**json.loads** function requires a string, and the content of the requests response is bytes. Changing _content_ to _text_ fixes the bug. 