### PR TITLE
VMRay: fix comparison of list and int instead of len and int

### DIFF
--- a/analyzers/VMRay/vmray.py
+++ b/analyzers/VMRay/vmray.py
@@ -89,7 +89,7 @@ class VMRayAnalyzer(Analyzer):
                 else:
                     level = "info"
 
-                if r["reports"] > 1:
+                if len(r["reports"]) > 1:
                     value = "{}( from scan {})".format(s["score"], i)
                 else:
                     value = "{}".format(s["score"])


### PR DESCRIPTION
Fix exception happening during taxonomy creation, unfortunately hidden by cortexutils.