### PR TITLE
MalwareBazaar: fix config

### DIFF
--- a/analyzers/MalwareBazaar/MalwareBazaar.json
+++ b/analyzers/MalwareBazaar/MalwareBazaar.json
@@ -6,7 +6,7 @@
   "version": "1.0",
   "baseConfig": "MalwareBazaar",
   "description": "Search hashes on MalwareBazaar.",
-  "dataTypeList": ["domain", "fqdn", "url", "hash", "ip"],
+  "dataTypeList": ["hash"],
   "command": "MalwareBazaar/MalwareBazaar_analyzer.py",
   "configurationItems": [    {
       "name": "api_key",


### PR DESCRIPTION
The config file allows to run the analyzer on not supported data types