### PR TITLE
Remove the invalid dataType email which is actually just mail

### DIFF
--- a/analyzers/MISP/MISP.json
+++ b/analyzers/MISP/MISP.json
@@ -13,7 +13,6 @@
     "uri_path",
     "user-agent",
     "hash",
-    "email",
     "mail",
     "mail_subject",
     "registry",

--- a/analyzers/OpenCTI/OpenCTI.json
+++ b/analyzers/OpenCTI/OpenCTI.json
@@ -13,7 +13,6 @@
     "uri_path",
     "user-agent",
     "hash",
-    "email",
     "mail",
     "mail_subject",
     "registry",

--- a/analyzers/SoltraEdge/Soltra_search.json
+++ b/analyzers/SoltraEdge/Soltra_search.json
@@ -5,7 +5,7 @@
     "url": "http://soltra.com/en/",
     "license" : "AGPL-V3",
     "description": "Query against Soltra Edge.",
-    "dataTypeList": ["domain", "ip", "url", "fqdn", "uri_path","user-agent", "hash", "email", "mail", "mail_subject" , "registry", "regexp", "other", "filename"],
+    "dataTypeList": ["domain", "ip", "url", "fqdn", "uri_path","user-agent", "hash", "mail", "mail_subject" , "registry", "regexp", "other", "filename"],
     "command": "SoltraEdge/soltra.py",
     "baseConfig": "Soltra_Edge",
     "config": {


### PR DESCRIPTION
The dataType `email` is not specified anywhere in Cortex, instead just `mail` is used everywhere else.

Therefore this PR removes the invalid, duplicate and redundant `email` dataType from a few analyzers.