### PR TITLE
Use Response.text instead of Response.content

### DIFF
--- a/analyzers/OTXQuery/otxquery.py
+++ b/analyzers/OTXQuery/otxquery.py
@@ -34,7 +34,7 @@ class OTXQueryAnalyzer(Analyzer):
         try:
             for section in sections:
                 queryurl = baseurl + section
-                ip_[section] = json.loads(requests.get(queryurl, headers=headers).content)
+                ip_[section] = json.loads(requests.get(queryurl, headers=headers).text)
 
             ip_general = ip_['general']
             ip_geo = ip_['geo']
@@ -64,7 +64,7 @@ class OTXQueryAnalyzer(Analyzer):
         try:
             for section in sections:
                 queryurl = baseurl + section
-                ip_[section] = json.loads(requests.get(queryurl, headers=headers).content)
+                ip_[section] = json.loads(requests.get(queryurl, headers=headers).text)
 
             result = {
                 'pulse_count': ip_.get('general', {}).get('pulse_info', {}).get('count', "0"),
@@ -98,7 +98,7 @@ class OTXQueryAnalyzer(Analyzer):
         try:
             for section in sections:
                 queryurl = baseurl + section
-                ip_[section] = json.loads(requests.get(queryurl, headers=headers).content)
+                ip_[section] = json.loads(requests.get(queryurl, headers=headers).text)
 
             if ip_['analysis']['analysis']:
                 # file has been analyzed before
@@ -142,7 +142,7 @@ class OTXQueryAnalyzer(Analyzer):
         try:
             for section in sections:
                 queryurl = baseurl + section
-                IP_[section] = json.loads(requests.get(queryurl, headers=headers).content)
+                IP_[section] = json.loads(requests.get(queryurl, headers=headers).text)
 
             self.report({
                 'pulse_count': IP_.get('general', {}).get('pulse_info', {}).get('count', "0"),


### PR DESCRIPTION
In python3 bytes and string are no longer the same thing.
Response.content returns bytes and json.loads expects string.
Reponse.text returns string and can be used instead of Response.content