### PR TITLE
Small enhancement for encrypted zips

### DIFF
--- a/analyzers/FileInfo/fileinfo_analyzer.py
+++ b/analyzers/FileInfo/fileinfo_analyzer.py
@@ -61,13 +61,17 @@ class FileInfoAnalyzer(Analyzer):
         for module in available_submodules:
             if module.check_file(file=self.filepath, filetype=self.filetype, filename=self.filename,
                                  mimetype=self.mimetype):
-                module_results = module.analyze_file(self.filepath)
-                module_summaries = module.module_summary()
-                results.append({
-                    'submodule_name': module.name,
-                    'results': module_results,
-                    'summary': module_summaries
-                })
+                try:                 
+                    module_results = module.analyze_file(self.filepath)
+                    module_summaries = module.module_summary()
+                
+                    results.append({
+                        'submodule_name': module.name,
+                        'results': module_results,
+                        'summary': module_summaries
+                    })
+                except:
+                    print("ERROR. exception occured")
 
         self.report({'results': results})
 

--- a/analyzers/FileInfo/fileinfo_analyzer.py
+++ b/analyzers/FileInfo/fileinfo_analyzer.py
@@ -71,7 +71,7 @@ class FileInfoAnalyzer(Analyzer):
                         'summary': module_summaries
                     })
                 except:
-                    print("ERROR. exception occured")
+                    pass
 
         self.report({'results': results})
 


### PR DESCRIPTION
We had a few cases that had .msg files with encrypted zips as an attachment. The FileInfo analyzer didn't handle that properly and it crashed.
To fix this I added a simple try except statement. I my test setup it analyzes the .msg and says in the attachment part that the zip is encrypted and cannot be read. I think this is better then not being able to analyze the whole email.