### PR TITLE
[OSCD] Vulners analyzer

### DIFF
--- a/analyzers/Vulners/Vulners_CVE.json
+++ b/analyzers/Vulners/Vulners_CVE.json
@@ -1,0 +1,23 @@
+{
+  "name": "Vulners_CVE",
+  "version": "1.0",
+  "author": "Dmitry Uchakin, Vulners team",
+  "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
+  "license": "AGPL-V3",
+  "description": "Get information about CVE from powerful Vulners database.",
+  "dataTypeList": ["cve"],
+  "command": "Vulners/vulners_analyzer.py",
+  "baseConfig": "Vulners",
+  "config": {
+    "service": "vulnerability"
+  },
+  "configurationItems": [
+    {
+      "name": "key",
+      "description": "API key for Vulners",
+      "type": "string",
+      "multi": false,
+      "required": true
+    }
+  ]
+}

--- a/analyzers/Vulners/Vulners_IOC.json
+++ b/analyzers/Vulners/Vulners_IOC.json
@@ -1,0 +1,23 @@
+{
+  "name": "Vulners_IOC",
+  "version": "1.0",
+  "author": "Dmitry Uchakin, Vulners team",
+  "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
+  "license": "AGPL-V3",
+  "description": "Get information from the RST Threat Feed, which integrated with Vulners, for a domain, url or an IP address.",
+  "dataTypeList": ["url", "domain", "ip"],
+  "command": "Vulners/vulners_analyzer.py",
+  "baseConfig": "Vulners",
+  "config": {
+    "service": "ioc"
+  },
+  "configurationItems": [
+    {
+      "name": "key",
+      "description": "API key for Vulners",
+      "type": "string",
+      "multi": false,
+      "required": true
+    }
+  ]
+}

--- a/analyzers/Vulners/requirements.txt
+++ b/analyzers/Vulners/requirements.txt
@@ -1,0 +1,2 @@
+cortexutils
+vulners

--- a/analyzers/Vulners/vulners_analyzer.py
+++ b/analyzers/Vulners/vulners_analyzer.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+from cortexutils.analyzer import Analyzer
+import vulners
+
+
+class VulnersAnalyzer(Analyzer):
+
+    def __init__(self):
+        Analyzer.__init__(self)
+        self.service = self.get_param('config.service', None, 'Service parameter is missing')
+        self.api_key = self.get_param('config.key', None, 'Missing vulners api key')
+        self.vulners = vulners.Vulners(api_key=self.api_key)
+
+    def summary(self, raw):
+        taxonomies = []
+        namespace = "Vulners"
+        if raw['service'] == 'ioc':
+            predicate = "IOC"
+            tags = ', '.join(raw['tags'])
+            if raw['fp_descr'] and not raw['tags']:
+                level = 'informative'
+                value = f"{raw['ioc_score']} score"
+            elif raw['fp_descr'] and raw['tags']:
+                level = 'suspicious'
+                value = f"{raw['ioc_score']} score / tags: {tags} / possible FP descr: {raw['fp_descr']}"
+            else:
+                level = 'malicious'
+                value = f"{raw['ioc_score']} score / tags: {tags} "
+
+        if raw['service'] == 'vulnerability':
+            predicate = "CVE"
+            if not raw['exploits']:
+                level = 'suspicious'
+                value = f"CVSS score: {raw['cvss']['score']} / Vulners score: {raw['vulners_AI']} / No exploits"
+            else:
+                level = 'malicious'
+                value = f"CVSS score: {raw['cvss']['score']} / Vulners score: {raw['vulners_AI']} / Exploits {len(raw['exploits'])}"
+
+        taxonomies.append(self.build_taxonomy(level, namespace, predicate, value))
+        return {"taxonomies": taxonomies}
+
+    def run(self):
+        if self.service == 'ioc':
+            if self.data_type in ['ip', 'domain', 'url']:
+                data = self.get_param('data', None, 'Data is missing')
+                document_id = self.vulners.search(f"iocType:{self.data_type} AND {self.data_type}:{data}")
+                if document_id or document_id['type'] == 'rst':
+                    full_document_info = self.vulners.document(document_id[0]['id'],  fields=["*"])
+                    ioc_report = {
+                        'service': self.service,
+                        'first_seen': full_document_info['published'],
+                        'last_seen': full_document_info['lastseen'],
+                        'tags': full_document_info['tags'],
+                        'ioc_score': full_document_info['iocScore']['ioc_total'],
+                        'ioc_url': full_document_info['id'],
+                        'fp_descr': full_document_info['fp']['descr']
+                    }
+                    if self.data_type == 'ip':
+                        ioc_report['geo_info'] = full_document_info['geodata']
+                        ioc_report['asn_info'] = full_document_info['asn']
+
+                    self.report(ioc_report)
+                else:
+                    self.error('No data found')
+            else:
+                self.error('Invalid data type')
+
+        if self.service == 'vulnerability':
+            if self.data_type == 'cve':
+                data = self.get_param('data', None, 'Data is missing')
+                cve_info = self.vulners.document(data, fields=["*"])
+                cve_exploits = self.vulners.searchExploit(data)
+                full_cve_info = {}
+
+                if cve_info:
+                    full_cve_info = {
+                        'service': self.service,
+                        'title': cve_info['title'],
+                        'published': cve_info['published'],
+                        'modified': cve_info['modified'],
+                        'cvss3': cve_info['cvss3'],
+                        'cvss2': cve_info['cvss2'],
+                        'cvss': cve_info['cvss'],
+                        'vulners_AI': cve_info['enchantments']['vulnersScore'],
+                        'cwe': cve_info['cwe'],
+                        'description': cve_info['description'],
+                        'affectedSoftware': cve_info['affectedSoftware']
+                    }
+                else:
+                    self.error('No data for specified CVE was found')
+
+                if cve_exploits:
+                    full_exploit_info = []
+                    for exploit in cve_exploits:
+                        full_exploit_info.append({
+                            'title': exploit['title'],
+                            'published': exploit['published'],
+                            'url': exploit['vhref']
+                        })
+
+                    full_cve_info['exploits'] = full_exploit_info
+                else:
+                    full_cve_info['exploits'] = False
+
+                self.report(full_cve_info)
+            else:
+                self.error('Invalid data type')
+
+
+if __name__ == '__main__':
+    VulnersAnalyzer().run()

--- a/thehive-templates/Vulners_CVE_1_0/long.html
+++ b/thehive-templates/Vulners_CVE_1_0/long.html
@@ -1,0 +1,80 @@
+<!-- Success -->
+<div class="panel panel-info" ng-if="success">
+    <div class="panel-heading">
+        Vulners information for <strong>{{artifact.data | fang}}</strong>
+    </div>
+    <div class="panel-body">
+        <h3 align="center"><b>{{artifact.data}}</b></h3>
+        <dl class="dl-horizontal">
+            <dt>Published: </dt><dd>{{content.published | limitTo : 10}}</dd>
+            <dt>Modified: </dt><dd>{{content.published | limitTo : 10}}</dd>
+        </dl>
+        <dl class="dl-horizontal" ng-if="content.cvss2">
+            <dt>CVSSv2.0: </dt><dd>{{content.cvss2.cvssV2.baseScore}}</dd>
+        </dl>
+        <dl class="dl-horizontal" ng-if="content.cvss3">
+            <dt>CVSSv3.1: </dt><dd>{{content.cvss3.cvssV3.baseScore}}</dd>
+        </dl>
+        <dl class="dl-horizontal" ng-if="content.vulners_AI">
+            <dt>Vulners Score: </dt> <dd>{{content.vulners_AI}}</dd>
+        </dl>
+        <dl class="dl-horizontal" ng-if="content.cwe">
+            <dt>CWE: </dt>
+            <dd>
+                <span class="label"
+                      ng-style="{'border':'1px solid','color': '#000000', 'background-color': md.color}">
+                    {{content.cwe[0]}}
+                </span>
+            </dd>
+        </dl>
+        <dl class="dl-horizontal" ng-if="content.exploits">
+            <dt>Exploits: </dt> <dd style="color:#ff0000">Yes</dd>
+        </dl>
+        <hr>
+        <h3>Description</h3>
+        <p>{{content.description}}</p>
+        <hr>
+        <h3>Affected products</h3>
+        <table class="table table-stripped">
+            <tr>
+                <th>Product name</th>
+                <th>Product version</th>
+            </tr>
+            <tr ng-repeat="soft in content.affectedSoftware">
+                <td>{{soft.name}}</td>
+                <td>{{soft.version}}</td>
+            </tr>
+        </table>
+        <p><br>Source info:
+        <a href="https://vulners.com/cve/{{artifact.data}}" target="_blank">https://vulners.com/cve/{{artifact.data}}</a>
+    </p>
+    </div><br />
+
+    <div class="panel panel-info" ng-if="content.exploits">
+        <div class="panel-heading">
+            <strong>Exploits</strong>
+        </div>
+
+        <div class="panel-body">
+            <dl class="dl-horizontal" ng-repeat="exploit in content.exploits">
+                <dt>Title: </dt> <dd>{{exploit.title}}</dd>
+                <dt>Published: </dt> <dd>{{exploit.published | limitTo : 10}}</dd>
+                <dt>Exploit url: </dt> <dd><a href="{{exploit.url}}" target="_blank">{{exploit.url}}</a></dd>
+                <hr>
+            </dl>
+        </div>
+    </div>
+</div>
+
+<!-- General error  -->
+<div class="panel panel-danger" ng-if="!success">
+    <div class="panel-heading">
+        <strong>{{(artifact.data || artifact.attachment.name) | fang}}</strong>
+    </div>
+    <div class="panel-body">
+        <dl class="dl-horizontal" ng-if="content.errorMessage">
+            <dt><i class="fa fa-warning"></i> ANALYZERNAME: </dt>
+            <dd class="wrap">{{content.errorMessage}}</dd>
+        </dl>
+    </div>
+</div>

--- a/thehive-templates/Vulners_CVE_1_0/short.html
+++ b/thehive-templates/Vulners_CVE_1_0/short.html
@@ -1,0 +1,6 @@
+<span class="label" ng-repeat="t in content.taxonomies"
+  ng-class="{'info': 'label-info', 'safe': 'label-success',
+  'suspicious': 'label-warning',
+  'malicious':'label-danger'}[t.level]">
+    {{t.namespace}}:{{t.predicate}}={{t.value}}
+</span>

--- a/thehive-templates/Vulners_IOC_1_0/long.html
+++ b/thehive-templates/Vulners_IOC_1_0/long.html
@@ -1,0 +1,70 @@
+<div class="panel panel-ingo" ng-if="success">
+  <div class="panel-heading">
+    Vulners information for <strong>{{artifact.data | fang}}</strong>
+  </div>
+  <div class="panel-body">
+    <div>
+      <dl class="dl-horizontal">
+        <dt>First seen</dt>
+        <dd>{{content.first_seen | limitTo : 10}}</dd>
+      </dl>
+      <dl class="dl-horizontal">
+        <dt>Last seen</dt>
+        <dd>{{content.last_seen | limitTo : 10}}</dd>
+      </dl>
+      <dl class="dl-horizontal">
+        <dt>Score</dt>
+        <dd>{{content.ioc_score}}</dd>
+      </dl>
+      <dl class="dl-horizontal">
+        <dt ng-if="content.tags">Tags</dt>
+        <dd ng-if="content.tags">
+          <span ng-repeat="tag in content.tags" class="label label-danger">
+            {{tag}}
+          </span>
+        </dd>
+      </dd>
+      </dl>
+      <dl class="dl-horizontal" ng-if="content.fp_descr">
+        <dt>Possible FP</dt>
+        <dd>
+          <span class="label label-warning">
+            {{content.fp_descr}}
+          </span>
+        </dd>
+      </dl>
+      <dl class="dl-horizontal" ng-if="content.asn_info">
+        <dt>Asn info</dt>
+        <dd>
+          ASN {{content.asn_info.num}}: First IP {{content.asn_info.firstip.netv4}}, Last IP {{content.asn_info.lastip.netv4}}<br />
+          ASN name "{{content.asn_info.isp}}"<br />
+          ASN hosts {{content.asn_info.domains}} domains<br />
+        </dd>
+      </dl>
+      <dl class="dl-horizontal" ng-if="content.geo_info">
+        <dt>Geo info</dt>
+        <dd>
+          Country: {{content.geo_info.country}}<br />
+          Region: {{content.geo_info.region}}<br />
+          City: {{content.geo_info.city}}<br />
+        </dd>
+      </dl>
+    </div>
+    <p><br>Source info:
+        <a href="https://vulners.com/rst/{{content.ioc_url}}" target="_blank">https://vulners.com/rst/{{content.ioc_url}}</a>
+    </p>
+  </div>
+</div>
+
+<!-- General error  -->
+<div class="panel panel-danger" ng-if="!success">
+  <div class="panel-heading">
+    <strong>{{(artifact.data) | fang}}</strong>
+  </div>
+  <div class="panel-body">
+    <dl class="dl-horizontal" ng-if="content.errorMessage">
+      <dt><i class="fa fa-warning"></i> ANALYZERNAME: </dt>
+      <dd class="wrap">{{content.errorMessage}}</dd>
+    </dl>
+  </div>
+</div>

--- a/thehive-templates/Vulners_IOC_1_0/short.html
+++ b/thehive-templates/Vulners_IOC_1_0/short.html
@@ -1,0 +1,6 @@
+<span class="label" ng-repeat="t in content.taxonomies"
+  ng-class="{'info': 'label-info', 'safe': 'label-success',
+  'suspicious': 'label-warning',
+  'malicious':'label-danger'}[t.level]">
+    {{t.namespace}}:{{t.predicate}}={{t.value}}
+</span>


### PR DESCRIPTION
1. **Vulners_IOC**: As a result of collaboration between Vulners and RST Threat Feed, the idea was to send IOC analysis results through theHive analyzer: [blog post](http://vulners.blog/2020/09/10/iocs-for-you-with-vulners)
2. **Vulners_CVE**: Vulners have a strong vulnerability database. This data is useful if:
"if the case (incident) is related to the exploitation of a vulnerability, then the analyst (manually / automatically) can add it to observables and quickly get all the basic information on it in order to continue analyzing the case."
By default theHive does not have a "cve" type to be observables, so we have to add it to Administrator Settings: 


Vulners API KEY available in the user's profile after registration: [vulners.com](https://vulners.com)

P.S. part of [OSCD](https://oscd.community/sprints/sprint_2.html) sprint