### PR TITLE
[OSCD Initiative] Add Azure Authentication Token Revokation Responder

### DIFF
--- a/analyzers/URLhaus/URLhaus_analyzer.py
+++ b/analyzers/URLhaus/URLhaus_analyzer.py
@@ -35,7 +35,8 @@ class URLhausAnalyzer(Analyzer):
         namespace = "URLhaus"
 
         if raw['query_status'] == 'no_results' \
-        or raw['query_status'] == 'ok' and raw['md5_hash'] == None and raw['sha256_hash'] == None:
+        or (raw['query_status'] == 'ok' and not raw.get('md5_hash', None) \
+        and not raw.get('sha256_hash', None)):
             taxonomies.append(self.build_taxonomy(
                 'info',
                 namespace,

--- a/responders/AzureTokenRevoker/AzureTokenRevoker.json
+++ b/responders/AzureTokenRevoker/AzureTokenRevoker.json
@@ -5,7 +5,7 @@
     "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
     "license": "AGPL-V3",
     "description": "Revoke all Microsoft Azure authentication session tokens for a list of User Principal Names",
-    "dataTypeList": ["thehive:case", "thehive:alert", "thehive:case_task", "thehive:case_artifact"],
+    "dataTypeList": ["thehive:case"],
     "command": "AzureTokenRevoker.py",
     "baseConfig": "AzureTokenRevoker",
     "configurationItems": [
@@ -23,12 +23,6 @@
         },
         {"name": "client_secret",
         "description": "Secret for Azure AD Registered Application",
-        "type": "string",
-        "multi": false,
-        "required": true
-        },
-        {"name": "user",
-        "description": "A User Principal Name to invalidate all current authentication tokens for (Example: username@domain.com",
         "type": "string",
         "multi": false,
         "required": true

--- a/responders/AzureTokenRevoker/AzureTokenRevoker.json
+++ b/responders/AzureTokenRevoker/AzureTokenRevoker.json
@@ -1,0 +1,38 @@
+{
+    "name": "AzureTokenRevoker",
+    "version": "1.0",
+    "author": "Daniel Weiner @dmweiner",
+    "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
+    "license": "AGPL-V3",
+    "description": "Revoke all Microsoft Azure authentication session tokens for a list of User Principal Names",
+    "dataTypeList": ["thehive:case", "thehive:alert", "thehive:case_task", "thehive:case_artifact"],
+    "command": "AzureTokenRevoker.py",
+    "baseConfig": "AzureTokenRevoker",
+    "configurationItems": [
+        {"name": "redirect_uri",
+        "description": "Azure AD Application URI (Example: https://login.microsoftonline.com/TENANTIDHERE/oauth2/token)",
+        "type": "string",
+        "multi": false,
+        "required": true
+        },
+        {"name": "client_id",
+        "description": "Client ID/Application ID of Azure AD Registered App",
+        "type": "string",
+        "multi": false,
+        "required": true
+        },
+        {"name": "client_secret",
+        "description": "Secret for Azure AD Registered Application",
+        "type": "string",
+        "multi": false,
+        "required": true
+        },
+        {"name": "user",
+        "description": "A User Principal Name to invalidate all current authentication tokens for (Example: username@domain.com",
+        "type": "string",
+        "multi": false,
+        "required": true
+        }
+    ]
+
+}

--- a/responders/AzureTokenRevoker/AzureTokenRevoker.py
+++ b/responders/AzureTokenRevoker/AzureTokenRevoker.py
@@ -1,0 +1,64 @@
+import json
+import requests
+import cortexutils
+import traceback
+import datetime
+# Process json inputs
+
+from cortexutils.responder import Responder
+
+# Initialize Azure Class
+class AzureTokenRevoker(Responder):
+    def __init__(self):
+        Responder.__init__(self)
+        self.client_id = self.get_params('config.client_id', None, 'Azure AD Application ID/Client ID Missing')
+        self.client_secret = self.get_params('config.client_secret', None, 'Azure AD Registered Application Client Secret Missing')
+        self.redirect_uri = self.get_params('config.redirect_uri', None, 'Set a redirect URI in Azure AD Registered Application. (ex. https://logon.microsoftonline.<tenant id>/oauth2/token)')
+        self.user = self.get_params('user', None, 'No UPN supplied to revoke credentials for')
+        self.time = ''
+    def run(self):
+        try:
+            base_resource = "https://graph.microsoft.com"
+
+            token_data = {
+                "grant_type": "client_credentials",
+                'client_id': self.client_id,
+                'client_secret': self.client_secret,
+                'resource': 'https://graph.microsoft.com',
+                'scope': 'https://graph.microsoft.com'
+                }
+
+
+            #Authenticate to the graph api 
+
+            token_r = requests.post(self.redirect_uri, data=token_data)
+            token = token_r.json().get('access_token')
+
+            if token_r.status_code != 200:
+                self.error('Failure to obtain azure access token: {}'.format(token_r.content))
+
+            # Set headers for future requests
+            headers = {
+                'Authorization': 'Bearer {}'.format(token)
+            }
+
+            base_url = 'https://graph.microsoft.com/v1.0/'
+            
+            r = requests.post(base_url + 'users/{}/revokeSignInSessions'.format(user), headers=headers)
+
+            if r.status_code != 200:
+                self.error('Failure to revoke access tokens of user {}: {}'.format(user, r.content))
+            
+            else:
+                #record time of successful auth token revokation
+                self.time = datetime.datetime.now()
+        
+        except Exception as ex:
+            self.error(traceback.format_exc())
+
+    def operations(self, raw):
+        #Needs to be changed
+        return [self.build_operation('AddTagToArtifact', tag='AzureAD:UserAADAuthTokensReset{}'.format(self.time))]
+
+if __name__ == '__main__':
+    AzureTokenRevoker().run()

--- a/responders/AzureTokenRevoker/AzureTokenRevoker.py
+++ b/responders/AzureTokenRevoker/AzureTokenRevoker.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # encoding: utf-8
-
-import json
+#Author: Daniel Weiner @dmweiner
 import requests
 import traceback
 import datetime

--- a/responders/AzureTokenRevoker/AzureTokenRevoker.py
+++ b/responders/AzureTokenRevoker/AzureTokenRevoker.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # encoding: utf-8
-#Author: Daniel Weiner @dmweiner
+# Author: Daniel Weiner @dmweiner
 import requests
 import traceback
 import datetime
@@ -52,7 +52,7 @@ class AzureTokenRevoker(Responder):
             
             else:
                 #record time of successful auth token revokation
-                self.time = datetime.datetime.utcnow().st
+                self.time = datetime.datetime.utcnow()
         
         except Exception as ex:
             self.error(traceback.format_exc())

--- a/responders/AzureTokenRevoker/AzureTokenRevoker.py
+++ b/responders/AzureTokenRevoker/AzureTokenRevoker.py
@@ -1,10 +1,10 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
 import json
 import requests
-import cortexutils
 import traceback
 import datetime
-# Process json inputs
-
 from cortexutils.responder import Responder
 
 # Initialize Azure Class
@@ -14,10 +14,12 @@ class AzureTokenRevoker(Responder):
         self.client_id = self.get_params('config.client_id', None, 'Azure AD Application ID/Client ID Missing')
         self.client_secret = self.get_params('config.client_secret', None, 'Azure AD Registered Application Client Secret Missing')
         self.redirect_uri = self.get_params('config.redirect_uri', None, 'Set a redirect URI in Azure AD Registered Application. (ex. https://logon.microsoftonline.<tenant id>/oauth2/token)')
-        self.user = self.get_params('user', None, 'No UPN supplied to revoke credentials for')
         self.time = ''
     def run(self):
         try:
+            self.user = self.get_params('data.data', None, 'No UPN supplied to revoke credentials for')
+            if not self.user:
+                self.error("No user supplied")
             base_resource = "https://graph.microsoft.com"
 
             token_data = {
@@ -44,21 +46,21 @@ class AzureTokenRevoker(Responder):
 
             base_url = 'https://graph.microsoft.com/v1.0/'
             
-            r = requests.post(base_url + 'users/{}/revokeSignInSessions'.format(user), headers=headers)
+            r = requests.post(base_url + 'users/{}/revokeSignInSessions'.format(self.user), headers=headers)
 
             if r.status_code != 200:
-                self.error('Failure to revoke access tokens of user {}: {}'.format(user, r.content))
+                self.error('Failure to revoke access tokens of user {}: {}'.format(self.user, r.content))
             
             else:
                 #record time of successful auth token revokation
-                self.time = datetime.datetime.now()
+                self.time = datetime.datetime.utcnow().st
         
         except Exception as ex:
             self.error(traceback.format_exc())
+        # Build report to return to Cortex
+        full_report = {"message": "User {} authentication tokens successfully revoked at {}".format(self.user, self.time)}
+        self.report(full_report)
 
-    def operations(self, raw):
-        #Needs to be changed
-        return [self.build_operation('AddTagToArtifact', tag='AzureAD:UserAADAuthTokensReset{}'.format(self.time))]
 
 if __name__ == '__main__':
     AzureTokenRevoker().run()

--- a/responders/AzureTokenRevoker/requirements.txt
+++ b/responders/AzureTokenRevoker/requirements.txt
@@ -1,0 +1,3 @@
+cortexutils
+requests
+datetime


### PR DESCRIPTION
Hello, please see the supplied AzureTokenRevoker responder .py, .json, and requirements.txt files.

Two outstanding issues within the responder's .py codew:
1.) I was not able to clear up, is what the get_params data path was for a submitted UPN within a case. Would it be "data.data"? Or something else?

2.) Will a self.report statement with a message be sufficient as a return of success? Or is there some other object I should be passing back to TheHive?