### PR TITLE
Update mnemonic pdns.py with correct API URI

### DIFF
--- a/analyzers/MnemonicPDNS/pdns.py
+++ b/analyzers/MnemonicPDNS/pdns.py
@@ -10,7 +10,7 @@ class PDNSv3(Analyzer):
     def __init__(self):
         Analyzer.__init__(self)
 
-        self.base_url = "https://portal.mnemonic.no/web/api/pdns/v3"
+        self.base_url = "https://api.mnemonic.no/pdns/v3"
         self.apikey = self.get_param("config.key", None)
         self.service = self.get_param('config.service', None, 'Service parameter is missing')
 


### PR DESCRIPTION
The current API URI to mnemonics PDNS service is deprecated/unsupported, and will be removed.