### PR TITLE
Change the link back to VirusTotal Template using content.permalink

### DIFF
--- a/thehive-templates/VirusTotal_Scan_3_0/long.html
+++ b/thehive-templates/VirusTotal_Scan_3_0/long.html
@@ -21,12 +21,12 @@
                     <dt>Last analysis date</dt>
                     <dd>{{content.scan_date}}</dd>
                 </dl>
-                <dl class="dl-horizontal" ng-if="artifact.dataType === 'url'">
+                <dl class="dl-horizontal" ng-if="content.permalink">
                     <dt>Virus Total</dt>
                     <dd>
                         <span>
                             <i class="fa fa-search"></i>
-                            <a ng-href="https://www.virustotal.com/en/url/{{artifact.data | sha256}}/analysis/" target="_blank">
+                            <a href="{{content.permalink}}" target="_blank">
                                 View Full Report</a>
                         </span>
                     </dd>


### PR DESCRIPTION
For VirusTotal_Scan long report summary, check if content.permalink
exists, and use that to link back to VirusTotal report instead of
hand-crafted link, only when the scan was a scan of a URL.

I don't know why the template had the link back only set for URL scans, however, I found that all types of scans seem to provide a permalink, so I only check if content.permalink exists, and if so, use that as the link back to VirusTotal.

Additionally I also observed, that the former hand crafted link back to VirusTotal did not worked for all URL scans. 