### PR TITLE
Included expiringdict to workaround checkdmarc broken dependancy.

### DIFF
--- a/analyzers/DomainMailSPFDMARC/requirements.txt
+++ b/analyzers/DomainMailSPFDMARC/requirements.txt
@@ -1,1 +1,2 @@
 checkdmarc
+expiringdict


### PR DESCRIPTION
Installation of checkdmarc fails due to it's own lack of dependency inclusion. Workaround implemented here for Cortex-Analyzer deployments.