### PR TITLE
Fix splitting inside parsed header extraction.

### DIFF
--- a/analyzers/EmlParser/parse.py
+++ b/analyzers/EmlParser/parse.py
@@ -84,12 +84,10 @@ def parseEml(filepath):
     with open(filepath, 'r') as f:
         raw_eml = f.read()
 
-    #parsing the headers with the email library
-    #cause eml_parser does not provide raw headers (as far as I know)
-    #splited string because it was returning the body inside 'Content-Type'
+    #HeaderParser adheres to rfc2821, and extracts all header, so no need to monkeypatch a split. 
     hParser = email.parser.HeaderParser()
     h = str(hParser.parsestr(raw_eml))
-    result['headers'] = h[:h.lower().index('content-type:')]
+    result['headers'] = h
 
     parsed_eml = eml_parser.eml_parser.decode_email(filepath, include_raw_body=True, include_attachment_data=True)
     #parsed_eml['header'].keys() gives:

--- a/analyzers/EmlParser/parse.py
+++ b/analyzers/EmlParser/parse.py
@@ -87,7 +87,7 @@ def parseEml(filepath):
     #HeaderParser adheres to rfc2821, and extracts all header, so no need to monkeypatch a split. 
     hParser = email.parser.HeaderParser()
     h = str(hParser.parsestr(raw_eml))
-    result['headers'] = h
+    result['headers'] = h[:h.lower().index('content-type: ')]
 
     parsed_eml = eml_parser.eml_parser.decode_email(filepath, include_raw_body=True, include_attachment_data=True)
     #parsed_eml['header'].keys() gives:


### PR DESCRIPTION
I dont know what initially caused this to be(besides the comment about body being parsed also, but my testing with a few different eml files i cannot replicate it original dev was probably using an old version of it, and future commits continued the regression), i can see in previous commits it was splitted by \r\n\r\n or \n\n. 

The email.parser lib already parses the whole header so there is no need for splitting inside the extracted headers. 

Currently the 'content-type:' splitting is causing mails from office365 to be parsed incorrectly by the program, as seen with arc headers..
 arc-message-signature: i=1; a=rsa-sha256; c=relaxed/relaxed;
 d=microsoft.com; s=[REDACTED];
 h=From:Date:Subject:Message-ID:------->Content-Type:<----------MIME-Version:X-MS-Exchange-SenderADCheck; (<- and -> is not actual syntax but to show case it)

Above is 8 lines into the header where as the original header is 224 lines long.