### PR TITLE
Cylance analyzer

### DIFF
--- a/analyzers/Cylance/Cylance.json
+++ b/analyzers/Cylance/Cylance.json
@@ -1,0 +1,47 @@
+{
+  "name": "Cylance",
+  "author": "Mikael Keri",
+  "license": "AGPL-V3",
+  "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
+  "version": "1.0",
+  "description": "Search for a specific hash, if there is a match, coresponding client information",
+  "dataTypeList": ["hash"],
+  "baseConfig": "Cylance",
+   "config": {
+      "check_tlp": true,
+      "max_tlp": 2,
+      "check_pap": true,
+      "max_pap": 2
+   },
+  "command": "Cylance/cylance.py",
+  "configurationItems": [
+  {
+      "name": "ten_id",
+      "description": "Tenant ID",
+      "type": "string",
+      "multi": false,
+      "required": true
+  },
+  {
+      "name": "app_id",
+      "description": "App ID",
+      "type": "string",
+      "multi": false,
+      "required": true
+  },
+  {
+      "name": "app_secret",
+      "description": "App Secret",
+      "type": "string",
+      "multi": false,
+      "required": true
+  },
+  {
+      "name": "region",
+      "description": "Portal region, : NA, US, APN, JP, APS, AU, EU, GOV, SA, SP",
+      "type": "string",
+      "multi": false,
+      "required": true
+   }
+ ]
+}

--- a/analyzers/Cylance/README.md
+++ b/analyzers/Cylance/README.md
@@ -1,0 +1,9 @@
+# Cylance hashlookup
+
+Cylance hash lookup enables you to query possible infected clients of yours using a SHA256 hash. 
+The response includes information about the matching sample(s) along with information about affected clients.
+
+# FAQ
+
+### Q: Why only SHA256
+Sadly, although the response data contains an MD5 hash, the API only allows you to query with a SHA256

--- a/analyzers/Cylance/cylance.py
+++ b/analyzers/Cylance/cylance.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
+import requests
+from cyapi.cyapi import CyAPI
+from cortexutils.analyzer import Analyzer
+
+class CylanceAnalyzer(Analyzer):
+    def __init__(self):
+        Analyzer.__init__(self)
+        self.tid = self.get_param('config.ten_id', None, 'Cylance Tenant ID is missing')
+        self.app_id = self.get_param('config.app_id', None, 'Cylance App ID is missing')
+        self.app_secret = self.get_param('config.app_secret', None, 'Cylance App secret is missing')
+        self.region = self.get_param('config.region', None, 'Cylance region is missing')
+        self.headers = {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json',
+            'User-Agent': 'Cortex-Analyzer'
+        }
+
+    def summary(self, raw):
+         taxonomies = []
+         namespace = "Cylance"
+
+         if raw['hashlookup'] == 'hash_not_found':
+            taxonomies.append(self.build_taxonomy(
+                'info',
+                namespace,
+                'Search',
+                'No results'
+            ))
+         else:
+            taxonomies.append(self.build_taxonomy(
+                'malicious',
+                namespace,
+                'Score',
+                raw['hashlookup']['sample'].get('cylance_score', 'Unknown')
+            ))
+
+
+         return {"taxonomies": taxonomies}
+
+    def run(self):
+        if self.data_type == 'hash':
+            data = self.get_param('data', None, 'Data is missing')
+            if len(data) != 64:
+             self.error('Only SHA256 is supported')
+
+            threats_results = {} 
+            API = CyAPI(self.tid, self.app_id, self.app_secret, self.region)
+            API.create_conn()
+            threats = API.get_threat_devices(data)
+
+            if threats.data:
+
+                for x in range(len(threats.data)):
+                    threats_results[x] = {'name': threats.data[x]['name'], 
+                                         'state': threats.data[x]['state'], 
+                                         'found': threats.data[x]['date_found'], 
+                                         'status': threats.data[x]['file_status'], 
+                                         'path': threats.data[x]['file_path'], 
+                                          'ip': " , ".join(threats.data[x]['ip_addresses'])}
+
+                if threats_results:
+                    threat = API.get_threat(data)
+                    threats_results['sample'] = {'sample_name': threat.data['name'], 
+                                                'sha256': threat.data['sha256'], 
+                                                'md5': threat.data['md5'], 
+                                                'signed': threat.data['signed'], 
+                                                'cylance_score': threat.data['cylance_score'], 
+                                                'av_industry': threat.data['av_industry'], 
+                                                'classification': threat.data['classification'], 
+                                                'sub_classification': threat.data['sub_classification'], 
+                                                'global_quarantined': threat.data['global_quarantined'], 
+                                                'safelisted': threat.data['safelisted'], 
+                                                'cert_publisher': threat.data['cert_publisher'], 
+                                                'cert_issuer': threat.data['cert_issuer'], 
+                                                'cert_timestamp': threat.data['cert_timestamp'], 
+                                                'file_size': threat.data['file_size'], 
+                                                'unique_to_cylance': threat.data['unique_to_cylance'], 
+                                                'running': threat.data['running'], 
+                                                'autorun': threat.data['auto_run'], 
+                                                'detected_by': threat.data['detected_by'] }
+            
+                self.report({'hashlookup': threats_results})
+            else:
+                self.report({'hashlookup': 'hash_not_found'})
+        else:
+           self.error('Invalid data type')
+
+if __name__ == '__main__':
+    CylanceAnalyzer().run()

--- a/analyzers/Cylance/requirements.txt
+++ b/analyzers/Cylance/requirements.txt
@@ -1,0 +1,2 @@
+cortexutils
+cyapi

--- a/thehive-templates/Cylance_1_0/long.html
+++ b/thehive-templates/Cylance_1_0/long.html
@@ -1,0 +1,146 @@
+<div class="panel panel-info" ng-if="success && content.hashlookup != 'hash_not_found'">
+	<div class="panel-heading">
+	Cylance Lookup: Sample Information 
+        <strong>{{artifact.data | fang}}</strong>
+	</div>
+	<!-- Hash details -->
+   <table class="table">
+           <tbody>
+            <div class="panel-body">
+          <div>
+              <dl class="dl-horizontal">
+                <dt>Sample Name: </dt>
+                <dd class="wrap">{{content.hashlookup.sample.sample_name|| "-"}}</dd>
+              </dl>
+               <dl class="dl-horizontal">
+                <dt>SHA256: </dt>
+                <dd class="wrap">{{content.hashlookup.sample.sha256 || "-"}}</dd>
+              </dl>
+              <dl class="dl-horizontal">
+                <dt>MD5: </dt>
+                <dd class="wrap">{{content.hashlookup.sample.md5 || "-"}}</dd>
+              </dl>
+              <dl class="dl-horizontal">
+                <dt>Signed: </dt>
+                <dd class="wrap">{{content.hashlookup.sample.signed || "-"}}</dd>
+              </dl>
+              <dl class="dl-horizontal">
+                <dt>Cylance Score: </dt>
+                <dd class="wrap">{{content.hashlookup.sample.cylance_score || "-"}}</dd>
+              </dl>
+              <dl class="dl-horizontal">
+                <dt>AV Industry: </dt>
+                <dd class="wrap">{{content.hashlookup.sample.av_industry || "-"}}</dd>
+              </dl>
+              <dl class="dl-horizontal">
+                <dt>Classification: </dt>
+                <dd class="wrap">{{content.hashlookup.sample.classification || "-"}}</dd>
+              </dl>
+              <dl class="dl-horizontal">
+                <dt>Sub Classification: </dt>
+                <dd class="wrap">{{content.hashlookup.sample.sub_classification|| "-"}}</dd>
+              </dl>
+              <dl class="dl-horizontal">
+                <dt>Global Quarantine: </dt>
+                <dd class="wrap">{{content.hashlookup.sample.global_quarantine || "-"}}</dd>
+              </dl>
+               <dl class="dl-horizontal">
+                <dt>Safelisted: </dt>
+                <dd class="wrap">{{content.hashlookup.sample.safelisted || "-"}}</dd>
+              </dl>
+               <dl class="dl-horizontal">
+                <dt>Cert Publisher: </dt>
+                <dd class="wrap">{{content.hashlookup.sample.cert_publisher || "-"}}</dd>
+              </dl>
+               <dl class="dl-horizontal">
+                <dt>Cert Issuer: </dt>
+                <dd class="wrap">{{content.hashlookup.sample.cert_issuer || "-"}}</dd>
+              </dl>
+               <dl class="dl-horizontal">
+                <dt>Cert Timestampt: </dt>
+                <dd class="wrap">{{content.hashlookup.sample.cert_timestamp || "-"}}</dd>
+              </dl>
+               <dl class="dl-horizontal">
+                <dt>File Size (bytes): </dt>
+                <dd class="wrap">{{content.hashlookup.sample.file_size || "-"}}</dd>
+              </dl>
+              <dl class="dl-horizontal">
+                <dt>Unique to Cylance: </dt>
+                <dd class="wrap">{{content.hashlookup.sample.unique_to_cylance || "-"}}</dd>
+              </dl>
+              <dl class="dl-horizontal">
+                <dt>Running: </dt>
+                <dd class="wrap">{{content.hashlookup.sample.running || "-"}}</dd>
+              </dl>
+              <dl class="dl-horizontal">
+                <dt>Autorun: </dt>
+                <dd class="wrap">{{content.hashlookup.sample.autorun || "-"}}</dd>
+              </dl>
+              <dl class="dl-horizontal">
+                <dt>Detected By: </dt>
+                <dd class="wrap">{{content.hashlookup.sample.detected_by || "-"}}</dd>
+              </dl>
+            </div>
+        </div>
+            </tbody>
+        </table>
+	</div>
+</div>
+<div class="panel panel-info" ng-if="success && content.hashlookup != 'hash_not_found'">
+	<div class="panel-heading">
+	Cylance Lookup: Host Information
+	</div>
+
+	<div class="panel-body">
+		<!-- Client details -->
+        <p ng-if="content.hashlookup == 0">
+            No result found.
+        </p>
+        <table class="table" ng-if="content.hashlookup">
+            <thead>
+                <th>Name</th>
+                <th>State</th>
+                <th>Found</th>
+                <th>Status</th>
+                <th>Path</th>
+                <th>IP</th>
+            </thead>
+            <tbody ng-repeat="r in content.hashlookup">
+                <tr>
+                    <td>{{r.name}}</td>
+                    <td>{{r.state}}</td>
+                    <td>{{r.found}}</td>
+                    <td>{{r.status}}</td>
+                    <td>{{r.path}}</td>
+                    <td>{{r.ip}}</td>
+                </tr>
+            </tbody>
+        </table>
+	</div>
+</div>
+<!-- No results -->
+<div class="panel panel-danger" ng-if="content.hashlookup == 'hash_not_found'">
+    <div class="panel-heading">
+        <strong>{{artifact.data | fang}}</strong>
+    </div>
+    <div class="panel-body">
+        <dl class="dl-horizontal">
+            <dt>
+                <i class="fa fa-warning"></i> Cylance:
+            </dt>
+            <dd class="wrap">No results</dd>
+        </dl>
+    </div>
+</div>
+<!-- General error  -->
+<div class="panel panel-danger" ng-if="!success">
+    <div class="panel-heading">
+        <strong>{{(artifact.data) | fang}}</strong>
+    </div>
+    <div class="panel-body">
+    	<dl class="dl-horizontal" ng-if="content.errorMessage">
+            <dt><i class="fa fa-warning"></i> Cylance: </dt>
+            <dd class="wrap">{{content.errorMessage}}</dd>
+        </dl>
+    </div>
+</div>

--- a/thehive-templates/Cylance_1_0/short.html
+++ b/thehive-templates/Cylance_1_0/short.html
@@ -1,0 +1,3 @@
+<span class="label" ng-repeat="t in content.taxonomies" ng-class="{'info': 'label-info', 'safe': 'label-success', 'suspicious': 'label-warning', 'malicious':'label-danger'}[t.level]">
+    {{t.namespace}}:{{t.predicate}}="{{t.value}}"
+</span>


### PR DESCRIPTION
A new analyzer for customers of Cylance(Blackberry), enables a hash lookup for any given SHA256* hash. In return if there is a match, you get information about the corresponding sample(s) and client(s) on which this sample has been detected. 

*) Yes, sadly only SHA256 is allowed in the API request