### PR TITLE
Mailer Responder | Create requirements.txt

### DIFF
--- a/responders/Mailer/requirements.txt
+++ b/responders/Mailer/requirements.txt
@@ -1,0 +1,1 @@
+cortexutils


### PR DESCRIPTION
The requirements.txt file seems to be missing resulting in the bug below
https://github.com/TheHive-Project/Cortex/issues/334