### PR TITLE
Fix incomplete headers in EmlParser

### DIFF
--- a/analyzers/EmlParser/parse.py
+++ b/analyzers/EmlParser/parse.py
@@ -96,7 +96,7 @@ def parseEml(filepath, job_directory):
     #splited string because it was returning the body inside 'Content-Type'
     hParser = email.parser.HeaderParser()
     h = str(hParser.parsestr(raw_eml))
-    result['headers'] = h[:h.lower().index('content-type:')]
+    result['headers'] = h[:h.lower().index('content-type: ')]
 
     parsed_eml = eml_parser.eml_parser.decode_email(filepath, include_raw_body=True, include_attachment_data=True)
     #parsed_eml['header'].keys() gives:


### PR DESCRIPTION
Currently the 'content-type:' splitting is causing mails from office365 to be parsed incorrectly by the program, as seen with arc headers..
arc-message-signature: i=1; a=rsa-sha256; c=relaxed/relaxed;
d=microsoft.com; s=[REDACTED];
h=From:Date:Subject:Message-ID:------->Content-Type:<----------MIME-Version:X-MS-Exchange-SenderADCheck; (<- and -> is not actual syntax but to show case it)

This ensures that only the first 'real' 'content-type: blah blah' will be indexed to.

fixes #976