### PR TITLE
New analyzers and templates for RiskIQ Illuminate

### DIFF
--- a/analyzers/RiskIQ/RiskIQ_Articles.json
+++ b/analyzers/RiskIQ/RiskIQ_Articles.json
@@ -1,0 +1,43 @@
+{
+  "author": "RiskIQ",
+  "baseConfig": "RiskIQ",
+  "command": "RiskIQ/_analyzer.py",
+  "config": {
+    "auto_extract": true,
+    "property": "articles"
+  },
+  "configurationItems": [
+    {
+      "description": "API username of the RiskIQ Illuminate or PassiveTotal account (usually an email address)",
+      "multi": false,
+      "name": "username",
+      "required": true,
+      "type": "string"
+    },
+    {
+      "description": "API key of the RiskIQ Illuminate or PassiveTotal account",
+      "multi": false,
+      "name": "api_key",
+      "required": true,
+      "type": "string"
+    },
+    {
+      "defaultValue": 180,
+      "description": "Number of days back to search for date-bounded historical queries",
+      "multi": false,
+      "name": "days_back",
+      "required": false,
+      "type": "number"
+    }
+  ],
+  "dataTypeList": [
+    "domain",
+    "fqdn",
+    "ip"
+  ],
+  "description": "RiskIQ: OSINT articles that reference an indicator.",
+  "license": "AGPL-V3",
+  "name": "RiskIQ_Articles",
+  "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
+  "version": "1.0"
+}

--- a/analyzers/RiskIQ/RiskIQ_Artifacts.json
+++ b/analyzers/RiskIQ/RiskIQ_Artifacts.json
@@ -1,0 +1,43 @@
+{
+  "author": "RiskIQ",
+  "baseConfig": "RiskIQ",
+  "command": "RiskIQ/_analyzer.py",
+  "config": {
+    "auto_extract": true,
+    "property": "artifacts"
+  },
+  "configurationItems": [
+    {
+      "description": "API username of the RiskIQ Illuminate or PassiveTotal account (usually an email address)",
+      "multi": false,
+      "name": "username",
+      "required": true,
+      "type": "string"
+    },
+    {
+      "description": "API key of the RiskIQ Illuminate or PassiveTotal account",
+      "multi": false,
+      "name": "api_key",
+      "required": true,
+      "type": "string"
+    },
+    {
+      "defaultValue": 180,
+      "description": "Number of days back to search for date-bounded historical queries",
+      "multi": false,
+      "name": "days_back",
+      "required": false,
+      "type": "number"
+    }
+  ],
+  "dataTypeList": [
+    "domain",
+    "fqdn",
+    "ip"
+  ],
+  "description": "RiskIQ: Illuminate / PassiveTotal project artifacts that match an indicator.",
+  "license": "AGPL-V3",
+  "name": "RiskIQ_Artifacts",
+  "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
+  "version": "1.0"
+}

--- a/analyzers/RiskIQ/RiskIQ_Certificates.json
+++ b/analyzers/RiskIQ/RiskIQ_Certificates.json
@@ -1,0 +1,43 @@
+{
+  "author": "RiskIQ",
+  "baseConfig": "RiskIQ",
+  "command": "RiskIQ/_analyzer.py",
+  "config": {
+    "auto_extract": true,
+    "property": "certificates"
+  },
+  "configurationItems": [
+    {
+      "description": "API username of the RiskIQ Illuminate or PassiveTotal account (usually an email address)",
+      "multi": false,
+      "name": "username",
+      "required": true,
+      "type": "string"
+    },
+    {
+      "description": "API key of the RiskIQ Illuminate or PassiveTotal account",
+      "multi": false,
+      "name": "api_key",
+      "required": true,
+      "type": "string"
+    },
+    {
+      "defaultValue": 180,
+      "description": "Number of days back to search for date-bounded historical queries",
+      "multi": false,
+      "name": "days_back",
+      "required": false,
+      "type": "number"
+    }
+  ],
+  "dataTypeList": [
+    "domain",
+    "fqdn",
+    "ip"
+  ],
+  "description": "RiskIQ: SSL/TLS certificates associated with an indicator.",
+  "license": "AGPL-V3",
+  "name": "RiskIQ_Certificates",
+  "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
+  "version": "1.0"
+}

--- a/analyzers/RiskIQ/RiskIQ_Components.json
+++ b/analyzers/RiskIQ/RiskIQ_Components.json
@@ -1,0 +1,43 @@
+{
+  "author": "RiskIQ",
+  "baseConfig": "RiskIQ",
+  "command": "RiskIQ/_analyzer.py",
+  "config": {
+    "auto_extract": true,
+    "property": "components"
+  },
+  "configurationItems": [
+    {
+      "description": "API username of the RiskIQ Illuminate or PassiveTotal account (usually an email address)",
+      "multi": false,
+      "name": "username",
+      "required": true,
+      "type": "string"
+    },
+    {
+      "description": "API key of the RiskIQ Illuminate or PassiveTotal account",
+      "multi": false,
+      "name": "api_key",
+      "required": true,
+      "type": "string"
+    },
+    {
+      "defaultValue": 180,
+      "description": "Number of days back to search for date-bounded historical queries",
+      "multi": false,
+      "name": "days_back",
+      "required": false,
+      "type": "number"
+    }
+  ],
+  "dataTypeList": [
+    "domain",
+    "fqdn",
+    "ip"
+  ],
+  "description": "RiskIQ: web components observed during crawls on a hostname.",
+  "license": "AGPL-V3",
+  "name": "RiskIQ_Components",
+  "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
+  "version": "1.0"
+}

--- a/analyzers/RiskIQ/RiskIQ_Cookies.json
+++ b/analyzers/RiskIQ/RiskIQ_Cookies.json
@@ -1,0 +1,43 @@
+{
+  "author": "RiskIQ",
+  "baseConfig": "RiskIQ",
+  "command": "RiskIQ/_analyzer.py",
+  "config": {
+    "auto_extract": true,
+    "property": "cookies"
+  },
+  "configurationItems": [
+    {
+      "description": "API username of the RiskIQ Illuminate or PassiveTotal account (usually an email address)",
+      "multi": false,
+      "name": "username",
+      "required": true,
+      "type": "string"
+    },
+    {
+      "description": "API key of the RiskIQ Illuminate or PassiveTotal account",
+      "multi": false,
+      "name": "api_key",
+      "required": true,
+      "type": "string"
+    },
+    {
+      "defaultValue": 180,
+      "description": "Number of days back to search for date-bounded historical queries",
+      "multi": false,
+      "name": "days_back",
+      "required": false,
+      "type": "number"
+    }
+  ],
+  "dataTypeList": [
+    "domain",
+    "fqdn",
+    "ip"
+  ],
+  "description": "RiskIQ: cookies observed during crawls on a hostname.",
+  "license": "AGPL-V3",
+  "name": "RiskIQ_Cookies",
+  "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
+  "version": "1.0"
+}

--- a/analyzers/RiskIQ/RiskIQ_HostpairChildren.json
+++ b/analyzers/RiskIQ/RiskIQ_HostpairChildren.json
@@ -1,0 +1,43 @@
+{
+  "author": "RiskIQ",
+  "baseConfig": "RiskIQ",
+  "command": "RiskIQ/_analyzer.py",
+  "config": {
+    "auto_extract": true,
+    "property": "hostpair_children"
+  },
+  "configurationItems": [
+    {
+      "description": "API username of the RiskIQ Illuminate or PassiveTotal account (usually an email address)",
+      "multi": false,
+      "name": "username",
+      "required": true,
+      "type": "string"
+    },
+    {
+      "description": "API key of the RiskIQ Illuminate or PassiveTotal account",
+      "multi": false,
+      "name": "api_key",
+      "required": true,
+      "type": "string"
+    },
+    {
+      "defaultValue": 180,
+      "description": "Number of days back to search for date-bounded historical queries",
+      "multi": false,
+      "name": "days_back",
+      "required": false,
+      "type": "number"
+    }
+  ],
+  "dataTypeList": [
+    "domain",
+    "fqdn",
+    "ip"
+  ],
+  "description": "RiskIQ: hosts with a child web component relationship to an IOC.",
+  "license": "AGPL-V3",
+  "name": "RiskIQ_HostpairChildren",
+  "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
+  "version": "1.0"
+}

--- a/analyzers/RiskIQ/RiskIQ_HostpairParents.json
+++ b/analyzers/RiskIQ/RiskIQ_HostpairParents.json
@@ -1,0 +1,43 @@
+{
+  "author": "RiskIQ",
+  "baseConfig": "RiskIQ",
+  "command": "RiskIQ/_analyzer.py",
+  "config": {
+    "auto_extract": true,
+    "property": "hostpair_parents"
+  },
+  "configurationItems": [
+    {
+      "description": "API username of the RiskIQ Illuminate or PassiveTotal account (usually an email address)",
+      "multi": false,
+      "name": "username",
+      "required": true,
+      "type": "string"
+    },
+    {
+      "description": "API key of the RiskIQ Illuminate or PassiveTotal account",
+      "multi": false,
+      "name": "api_key",
+      "required": true,
+      "type": "string"
+    },
+    {
+      "defaultValue": 180,
+      "description": "Number of days back to search for date-bounded historical queries",
+      "multi": false,
+      "name": "days_back",
+      "required": false,
+      "type": "number"
+    }
+  ],
+  "dataTypeList": [
+    "domain",
+    "fqdn",
+    "ip"
+  ],
+  "description": "RiskIQ: hosts with a parent web component relationship to an IOC.",
+  "license": "AGPL-V3",
+  "name": "RiskIQ_HostpairParents",
+  "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
+  "version": "1.0"
+}

--- a/analyzers/RiskIQ/RiskIQ_Malware.json
+++ b/analyzers/RiskIQ/RiskIQ_Malware.json
@@ -1,0 +1,43 @@
+{
+  "author": "RiskIQ",
+  "baseConfig": "RiskIQ",
+  "command": "RiskIQ/_analyzer.py",
+  "config": {
+    "auto_extract": true,
+    "property": "malware"
+  },
+  "configurationItems": [
+    {
+      "description": "API username of the RiskIQ Illuminate or PassiveTotal account (usually an email address)",
+      "multi": false,
+      "name": "username",
+      "required": true,
+      "type": "string"
+    },
+    {
+      "description": "API key of the RiskIQ Illuminate or PassiveTotal account",
+      "multi": false,
+      "name": "api_key",
+      "required": true,
+      "type": "string"
+    },
+    {
+      "defaultValue": 180,
+      "description": "Number of days back to search for date-bounded historical queries",
+      "multi": false,
+      "name": "days_back",
+      "required": false,
+      "type": "number"
+    }
+  ],
+  "dataTypeList": [
+    "domain",
+    "fqdn",
+    "ip"
+  ],
+  "description": "RiskIQ: malware hashes from various sources associated with an IOC.",
+  "license": "AGPL-V3",
+  "name": "RiskIQ_Malware",
+  "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
+  "version": "1.0"
+}

--- a/analyzers/RiskIQ/RiskIQ_Projects.json
+++ b/analyzers/RiskIQ/RiskIQ_Projects.json
@@ -1,0 +1,43 @@
+{
+  "author": "RiskIQ",
+  "baseConfig": "RiskIQ",
+  "command": "RiskIQ/_analyzer.py",
+  "config": {
+    "auto_extract": true,
+    "property": "projects"
+  },
+  "configurationItems": [
+    {
+      "description": "API username of the RiskIQ Illuminate or PassiveTotal account (usually an email address)",
+      "multi": false,
+      "name": "username",
+      "required": true,
+      "type": "string"
+    },
+    {
+      "description": "API key of the RiskIQ Illuminate or PassiveTotal account",
+      "multi": false,
+      "name": "api_key",
+      "required": true,
+      "type": "string"
+    },
+    {
+      "defaultValue": 180,
+      "description": "Number of days back to search for date-bounded historical queries",
+      "multi": false,
+      "name": "days_back",
+      "required": false,
+      "type": "number"
+    }
+  ],
+  "dataTypeList": [
+    "domain",
+    "fqdn",
+    "ip"
+  ],
+  "description": "RiskIQ: Illuminate / PassiveTotal projects that contain an artifact which matches an IOC.",
+  "license": "AGPL-V3",
+  "name": "RiskIQ_Projects",
+  "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
+  "version": "1.0"
+}

--- a/analyzers/RiskIQ/RiskIQ_Reputation.json
+++ b/analyzers/RiskIQ/RiskIQ_Reputation.json
@@ -1,0 +1,43 @@
+{
+  "author": "RiskIQ",
+  "baseConfig": "RiskIQ",
+  "command": "RiskIQ/_analyzer.py",
+  "config": {
+    "auto_extract": true,
+    "property": "reputation"
+  },
+  "configurationItems": [
+    {
+      "description": "API username of the RiskIQ Illuminate or PassiveTotal account (usually an email address)",
+      "multi": false,
+      "name": "username",
+      "required": true,
+      "type": "string"
+    },
+    {
+      "description": "API key of the RiskIQ Illuminate or PassiveTotal account",
+      "multi": false,
+      "name": "api_key",
+      "required": true,
+      "type": "string"
+    },
+    {
+      "defaultValue": 180,
+      "description": "Number of days back to search for date-bounded historical queries",
+      "multi": false,
+      "name": "days_back",
+      "required": false,
+      "type": "number"
+    }
+  ],
+  "dataTypeList": [
+    "domain",
+    "fqdn",
+    "ip"
+  ],
+  "description": "RiskIQ Illuminate Reputation Score for an indicator.",
+  "license": "AGPL-V3",
+  "name": "RiskIQ_Reputation",
+  "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
+  "version": "1.0"
+}

--- a/analyzers/RiskIQ/RiskIQ_Resolutions.json
+++ b/analyzers/RiskIQ/RiskIQ_Resolutions.json
@@ -1,0 +1,43 @@
+{
+  "author": "RiskIQ",
+  "baseConfig": "RiskIQ",
+  "command": "RiskIQ/_analyzer.py",
+  "config": {
+    "auto_extract": true,
+    "property": "resolutions"
+  },
+  "configurationItems": [
+    {
+      "description": "API username of the RiskIQ Illuminate or PassiveTotal account (usually an email address)",
+      "multi": false,
+      "name": "username",
+      "required": true,
+      "type": "string"
+    },
+    {
+      "description": "API key of the RiskIQ Illuminate or PassiveTotal account",
+      "multi": false,
+      "name": "api_key",
+      "required": true,
+      "type": "string"
+    },
+    {
+      "defaultValue": 180,
+      "description": "Number of days back to search for date-bounded historical queries",
+      "multi": false,
+      "name": "days_back",
+      "required": false,
+      "type": "number"
+    }
+  ],
+  "dataTypeList": [
+    "domain",
+    "fqdn",
+    "ip"
+  ],
+  "description": "RiskIQ: PDNS resolutions for an IOC.",
+  "license": "AGPL-V3",
+  "name": "RiskIQ_Resolutions",
+  "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
+  "version": "1.0"
+}

--- a/analyzers/RiskIQ/RiskIQ_Services.json
+++ b/analyzers/RiskIQ/RiskIQ_Services.json
@@ -1,0 +1,41 @@
+{
+  "author": "RiskIQ",
+  "baseConfig": "RiskIQ",
+  "command": "RiskIQ/_analyzer.py",
+  "config": {
+    "auto_extract": true,
+    "property": "services"
+  },
+  "configurationItems": [
+    {
+      "description": "API username of the RiskIQ Illuminate or PassiveTotal account (usually an email address)",
+      "multi": false,
+      "name": "username",
+      "required": true,
+      "type": "string"
+    },
+    {
+      "description": "API key of the RiskIQ Illuminate or PassiveTotal account",
+      "multi": false,
+      "name": "api_key",
+      "required": true,
+      "type": "string"
+    },
+    {
+      "defaultValue": 180,
+      "description": "Number of days back to search for date-bounded historical queries",
+      "multi": false,
+      "name": "days_back",
+      "required": false,
+      "type": "number"
+    }
+  ],
+  "dataTypeList": [
+    "ip"
+  ],
+  "description": "RiskIQ: services observed on an IP address.",
+  "license": "AGPL-V3",
+  "name": "RiskIQ_Services",
+  "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
+  "version": "1.0"
+}

--- a/analyzers/RiskIQ/RiskIQ_Subdomains.json
+++ b/analyzers/RiskIQ/RiskIQ_Subdomains.json
@@ -1,0 +1,42 @@
+{
+  "author": "RiskIQ",
+  "baseConfig": "RiskIQ",
+  "command": "RiskIQ/_analyzer.py",
+  "config": {
+    "auto_extract": true,
+    "property": "subdomains"
+  },
+  "configurationItems": [
+    {
+      "description": "API username of the RiskIQ Illuminate or PassiveTotal account (usually an email address)",
+      "multi": false,
+      "name": "username",
+      "required": true,
+      "type": "string"
+    },
+    {
+      "description": "API key of the RiskIQ Illuminate or PassiveTotal account",
+      "multi": false,
+      "name": "api_key",
+      "required": true,
+      "type": "string"
+    },
+    {
+      "defaultValue": 180,
+      "description": "Number of days back to search for date-bounded historical queries",
+      "multi": false,
+      "name": "days_back",
+      "required": false,
+      "type": "number"
+    }
+  ],
+  "dataTypeList": [
+    "fqdn",
+    "domain"
+  ],
+  "description": "RiskIQ: subdomains observed historically in pDNS records.",
+  "license": "AGPL-V3",
+  "name": "RiskIQ_Subdomains",
+  "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
+  "version": "1.0"
+}

--- a/analyzers/RiskIQ/RiskIQ_Summary.json
+++ b/analyzers/RiskIQ/RiskIQ_Summary.json
@@ -1,0 +1,43 @@
+{
+  "author": "RiskIQ",
+  "baseConfig": "RiskIQ",
+  "command": "RiskIQ/_analyzer.py",
+  "config": {
+    "auto_extract": true,
+    "property": "summary"
+  },
+  "configurationItems": [
+    {
+      "description": "API username of the RiskIQ Illuminate or PassiveTotal account (usually an email address)",
+      "multi": false,
+      "name": "username",
+      "required": true,
+      "type": "string"
+    },
+    {
+      "description": "API key of the RiskIQ Illuminate or PassiveTotal account",
+      "multi": false,
+      "name": "api_key",
+      "required": true,
+      "type": "string"
+    },
+    {
+      "defaultValue": 180,
+      "description": "Number of days back to search for date-bounded historical queries",
+      "multi": false,
+      "name": "days_back",
+      "required": false,
+      "type": "number"
+    }
+  ],
+  "dataTypeList": [
+    "domain",
+    "fqdn",
+    "ip"
+  ],
+  "description": "RiskIQ Illuminate and PassiveTotal datasets with records for an indicator.",
+  "license": "AGPL-V3",
+  "name": "RiskIQ_Summary",
+  "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
+  "version": "1.0"
+}

--- a/analyzers/RiskIQ/RiskIQ_Trackers.json
+++ b/analyzers/RiskIQ/RiskIQ_Trackers.json
@@ -1,0 +1,43 @@
+{
+  "author": "RiskIQ",
+  "baseConfig": "RiskIQ",
+  "command": "RiskIQ/_analyzer.py",
+  "config": {
+    "auto_extract": true,
+    "property": "trackers"
+  },
+  "configurationItems": [
+    {
+      "description": "API username of the RiskIQ Illuminate or PassiveTotal account (usually an email address)",
+      "multi": false,
+      "name": "username",
+      "required": true,
+      "type": "string"
+    },
+    {
+      "description": "API key of the RiskIQ Illuminate or PassiveTotal account",
+      "multi": false,
+      "name": "api_key",
+      "required": true,
+      "type": "string"
+    },
+    {
+      "defaultValue": 180,
+      "description": "Number of days back to search for date-bounded historical queries",
+      "multi": false,
+      "name": "days_back",
+      "required": false,
+      "type": "number"
+    }
+  ],
+  "dataTypeList": [
+    "domain",
+    "fqdn",
+    "ip"
+  ],
+  "description": "RiskIQ: trackers observed during a crawl on a host.",
+  "license": "AGPL-V3",
+  "name": "RiskIQ_Trackers",
+  "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
+  "version": "1.0"
+}

--- a/analyzers/RiskIQ/RiskIQ_Whois.json
+++ b/analyzers/RiskIQ/RiskIQ_Whois.json
@@ -1,0 +1,43 @@
+{
+  "author": "RiskIQ",
+  "baseConfig": "RiskIQ",
+  "command": "RiskIQ/_analyzer.py",
+  "config": {
+    "auto_extract": true,
+    "property": "whois"
+  },
+  "configurationItems": [
+    {
+      "description": "API username of the RiskIQ Illuminate or PassiveTotal account (usually an email address)",
+      "multi": false,
+      "name": "username",
+      "required": true,
+      "type": "string"
+    },
+    {
+      "description": "API key of the RiskIQ Illuminate or PassiveTotal account",
+      "multi": false,
+      "name": "api_key",
+      "required": true,
+      "type": "string"
+    },
+    {
+      "defaultValue": 180,
+      "description": "Number of days back to search for date-bounded historical queries",
+      "multi": false,
+      "name": "days_back",
+      "required": false,
+      "type": "number"
+    }
+  ],
+  "dataTypeList": [
+    "domain",
+    "fqdn",
+    "ip"
+  ],
+  "description": "RiskIQ Whois lookup for an indicator.",
+  "license": "AGPL-V3",
+  "name": "RiskIQ_Whois",
+  "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
+  "version": "1.0"
+}

--- a/analyzers/RiskIQ/_analyzer.py
+++ b/analyzers/RiskIQ/_analyzer.py
@@ -10,31 +10,37 @@ from _services import SERVICES
 class IlluminateAnalyzer(Analyzer):
     def __init__(self):
         Analyzer.__init__(self)
-        self.property = self.get_param('config.property', None, 'RiskIQ Illuminate Analyzer object property is missing')
-        self.username = self.get_param('config.username', None, 'RiskIQ Illuminate username is missing')
-        self.api_key = self.get_param('config.api_key', None, 'RiskIQ Illuminate api_key is missing')
-        self.days_back = self.get_param('config.days_back', None, 'RiskIQ Illuminate days_back is missing')
-        riqanalyzer.init(username=self.username, api_key=self.api_key)
-        riqanalyzer.set_date_range(days_back=self.days_back)
+        self._property = self.get_param('config.property', None, 'RiskIQ Illuminate Analyzer object property is missing')
+        self._username = self.get_param('config.username', None, 'RiskIQ Illuminate username is missing')
+        self._api_key = self.get_param('config.api_key', None, 'RiskIQ Illuminate api_key is missing')
+        self._days_back = self.get_param('config.days_back', None, 'RiskIQ Illuminate days_back is missing')
+        riqanalyzer.init(username=self._username, api_key=self._api_key)
+        riqanalyzer.set_date_range(days_back=self._days_back)
+        if self._property not in SERVICES:
+            self.error('Unknown property {}'.format(self._property))
+        self._svc = SERVICES[self._property]()
     
     def run(self):
-        target = self.get_data()
+        ioc = self.get_data()
         try:
-            obj = riqanalyzer.get_object(target)
+            ioc_obj = riqanalyzer.get_object(ioc)
         except riqanalyzer.AnalyzerError as e:
             self.error('Cannot instantiate object for that type of input: {}'.format(e))
         try:
-            value = getattr(obj, self.property)
-            data = value.as_dict
+            value = getattr(ioc_obj, self._property)
+        except AttributeError as e:
+            self.error('Unknown property {}'.format(self._property))
         except riqanalyzer.AnalyzerError as e:
-            self.error('Cannot get property "{0}": {1}'.format(self.property, e))
+            self.error('API error while getting property "{0}": {1}'.format(self._property, e))
+        try:
+            data = value.as_dict
+        except Exception as e:
+            self.error('Cannot transform property "{0}" to dictionary: {1}'.format(self._property, e))
+        data = self._svc.transform(data)
         self.report(data)
 
     def summary(self, raw):
-        if self.property not in SERVICES:
-            return []
-        svc = SERVICES[self.property]
-        return svc().summarize(raw)
+        return self._svc.summarize(raw)
 
 
 

--- a/analyzers/RiskIQ/_analyzer.py
+++ b/analyzers/RiskIQ/_analyzer.py
@@ -47,6 +47,12 @@ class IlluminateAnalyzer(Analyzer):
 
     def summary(self, raw):
         return self._svc.summarize(raw)
+    
+    def artifacts(self, report):
+        svc_artifacts = self._svc.build_artifacts(report)
+        if svc_artifacts is None:
+            return super().artifacts(report)
+        return svc_artifacts
 
 
 

--- a/analyzers/RiskIQ/_analyzer.py
+++ b/analyzers/RiskIQ/_analyzer.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
+from cortexutils.analyzer import Analyzer
+
+from passivetotal import analyzer as riqanalyzer
+from _services import SERVICES
+
+
+class IlluminateAnalyzer(Analyzer):
+    def __init__(self):
+        Analyzer.__init__(self)
+        self.property = self.get_param('config.property', None, 'RiskIQ Illuminate Analyzer object property is missing')
+        self.username = self.get_param('config.username', None, 'RiskIQ Illuminate username is missing')
+        self.api_key = self.get_param('config.api_key', None, 'RiskIQ Illuminate api_key is missing')
+        self.days_back = self.get_param('config.days_back', None, 'RiskIQ Illuminate days_back is missing')
+        riqanalyzer.init(username=self.username, api_key=self.api_key)
+        riqanalyzer.set_date_range(days_back=self.days_back)
+    
+    def run(self):
+        target = self.get_data()
+        try:
+            obj = riqanalyzer.get_object(target)
+        except riqanalyzer.AnalyzerError as e:
+            self.error('Cannot instantiate object for that type of input: {}'.format(e))
+        try:
+            value = getattr(obj, self.property)
+            data = value.as_dict
+        except riqanalyzer.AnalyzerError as e:
+            self.error('Cannot get property "{0}": {1}'.format(self.property, e))
+        self.report(data)
+
+    def summary(self, raw):
+        if self.property not in SERVICES:
+            return []
+        svc = SERVICES[self.property]
+        return svc().summarize(raw)
+
+
+
+
+if __name__ == '__main__':
+    IlluminateAnalyzer().run()
+    
+

--- a/analyzers/RiskIQ/_analyzer.py
+++ b/analyzers/RiskIQ/_analyzer.py
@@ -30,8 +30,14 @@ class IlluminateAnalyzer(Analyzer):
             value = getattr(ioc_obj, self._property)
         except AttributeError as e:
             self.error('Unknown property {}'.format(self._property))
+        except riqanalyzer.AnalyzerAPIError as e:
+            if e.status_code == 404:
+                self.report({'found': False, 'records': []})
+                return
+            else:
+                self.error('API error while getting property "{0}": {1}'.format(self._property, e))
         except riqanalyzer.AnalyzerError as e:
-            self.error('API error while getting property "{0}": {1}'.format(self._property, e))
+            self.error('Analyzer error while getting property "{0}": {1}'.format(self._property, e))
         try:
             data = value.as_dict
         except Exception as e:

--- a/analyzers/RiskIQ/_services.py
+++ b/analyzers/RiskIQ/_services.py
@@ -92,6 +92,9 @@ class IlluminateServiceFile():
         """
         return data
     
+    def build_artifacts(self, report):
+        return None
+    
 
 
 class Reputation(IlluminateServiceFile):
@@ -351,6 +354,24 @@ class Resolutions(IlluminateServiceFile):
         self._config['property'] = 'resolutions'
 
 
+
+class Subdomains(IlluminateServiceFile):
+    
+    def __init__(self):
+        super().__init__()
+        self._name = 'RiskIQ_Subdomains'
+        self._description = 'RiskIQ: subdomains observed historically in pDNS records.'
+        self._dataTypeList = ['fqdn','domain']
+        self._taxonomy_predicate = 'Subdomains'
+        self._taxonomy_level = 'info'
+        self._taxonomy_valuekey = 'totalrecords'
+        self._config['property'] = 'subdomains'
+    
+    def build_artifacts(self, report):
+        return [ { 'dataType': 'fqdn', 'data': r.get('hostname') } for r in report.get('records', []) ]
+
+
+
 class Trackers(IlluminateServiceFile):
     
     def __init__(self):
@@ -391,6 +412,7 @@ SERVICES = {
     'reputation': Reputation,
     'resolutions': Resolutions,
     'services': Services,
+    'subdomains': Subdomains,
     'trackers': Trackers,
     'summary': Summary,
     'whois': Whois,

--- a/analyzers/RiskIQ/_services.py
+++ b/analyzers/RiskIQ/_services.py
@@ -1,0 +1,434 @@
+import json
+
+
+class IlluminateServiceFile():
+    """Base service class for all RiskIQ service files."""
+
+    def __init__(self):
+        self._name = ''
+        self._version = '1.0'
+        self._author = 'RiskIQ'
+        self._url = 'https://github.com/TheHive-Project/Cortex-Analyzers'
+        self._license = 'AGPL-V3'
+        self._command = 'RiskIQ/_analyzer.py'
+        self._baseconfig = 'RiskIQ'
+        self._description = ''
+        self._dataTypeList = ["domain","fqdn","ip"]
+        self._taxonomy_namespace = 'RIQ'
+        self._taxonomy_predicate = 'RiskIQ'
+        self._taxonomy_valuekey = None
+        self._config = {
+            'property': None,
+            'auto_extract': True
+        }
+        self._configitems = [
+            {
+                'name': 'username',
+                'description': 'API username of the RiskIQ Illuminate or PassiveTotal account (usually an email address)',
+                'type': 'string',
+                'multi': False,
+                'required': True
+            },
+            {
+                'name': 'api_key',
+                'description': 'API key of the RiskIQ Illuminate or PassiveTotal account',
+                'type': 'string',
+                'multi': False,
+                'required': True
+            },
+            {
+                'name': 'days_back',
+                'description': 'Number of days back to search for date-bounded historical queries',
+                'type': 'number',
+                'multi': False,
+                'required': False,
+                'defaultValue': 180
+            },
+        ]
+    
+    def generate(self):
+        """Creates and writes a JSON file to the local directory describing this service."""
+        obj = {
+            'name': self._name,
+            'version': self._version,
+            'author': self._author,
+            'url': self._url,
+            'license': self._license,
+            'description': self._description,
+            'dataTypeList': self._dataTypeList,
+            'command': self._command,
+            'baseConfig': self._baseconfig,
+            'config': self._config,
+            'configurationItems': self._configitems,
+        }
+        filename = '{}.json'.format(self._name)
+        with open(filename, 'w') as f:
+            json.dump(obj, f, indent=2, sort_keys=True)
+    
+    def get_taxonomies(self, data):
+        """Get a list of taxonomies for this service."""
+        try:
+            level = self.get_taxonomy_level(data)
+        except AttributeError:
+            level = 'info'
+        return [
+            {
+                'level': level,
+                'namespace': self._taxonomy_namespace,
+                'predicate': self._taxonomy_predicate,
+                'value': data.get(self._taxonomy_valuekey, None),
+            }
+        ]
+
+    def summarize(self, data):
+        """Build summary data structure for data processed by this service."""
+        return { 'taxonomies': self.get_taxonomies(data) }
+    
+
+
+class Reputation(IlluminateServiceFile):
+    
+    def __init__(self):
+        super().__init__()
+        self._name = 'RiskIQ_Reputation'
+        self._description = 'RiskIQ Illuminate Reputation Score for an indicator.'
+        self._taxonomy_predicate = 'ReputationScore'
+        self._taxonomy_valuekey = 'score'
+        self._config['property'] = 'reputation'
+    
+    
+    def get_taxonomy_level(self, data):
+        levels = {
+            'SUSPICIOUS': 'suspicious',
+            'MALICIOUS': 'malicious',
+            'GOOD': 'info',
+            'UNKOWN': 'info'
+        }
+        return levels.get(data['classification'],'info')
+
+
+
+class Summary(IlluminateServiceFile):
+    
+    def __init__(self):
+        super().__init__()
+        self._name = 'RiskIQ_Summary'
+        self._description = 'RiskIQ Illuminate and PassiveTotal datasets with records for an indicator.'
+        self._taxonomy_predicate = 'Summary'
+        self._config['property'] = 'summary'
+    
+    def get_taxonomies(self, data):
+        levels = {
+            'malware_hashes': 'malicious',
+            'articles': 'suspicious',
+            'projects': 'suspicious'
+        }
+        taxonomies = []
+        for dataset, count in data.items():
+            if not type(count) is int:
+                continue
+            if dataset in levels.keys() and count > 0:
+                level = levels[dataset]
+            else:
+                level = 'info'
+            if dataset == 'total':
+                continue
+            if dataset == 'malware_hashes':
+                dataset = 'malware'
+            taxonomies.append({
+                'level': level,
+                'namespace': self._taxonomy_namespace,
+                'predicate': dataset.title(),
+                'value': count
+            })
+        return taxonomies
+
+
+
+class Whois(IlluminateServiceFile):
+    
+    def __init__(self):
+        super().__init__()
+        self._name = 'RiskIQ_Whois'
+        self._description = 'RiskIQ Whois lookup for an indicator.'
+        self._taxonomy_predicate = 'Whois'
+        self._config['property'] = 'whois'
+    
+    def get_taxonomies(self, data):
+        taxonomies = []
+        if 'age' in data:
+            age = data['age']
+            if age < 180:
+                level = 'suspicious'
+            taxonomies.append({
+                'level': 'suspicious' if age < 180 else 'info',
+                'namespace': self._taxonomy_namespace,
+                'predicate': 'Whois Age (days)',
+                'value': age
+            })
+        for email in data.get('emails',[]):
+            taxonomies.append({
+                'level': 'info',
+                'namespace': self._taxonomy_namespace,
+                'predicate': 'Whois Email',
+                'value': email
+            })
+        return taxonomies
+
+
+
+class SuspiciousCount:
+
+    def get_taxonomy_level(self, data):
+        return 'suspicious' if data.get('totalrecords',0) > 0 else 'info'
+
+
+
+class Articles(IlluminateServiceFile, SuspiciousCount):
+    
+    def __init__(self):
+        super().__init__()
+        self._name = 'RiskIQ_Articles'
+        self._description = 'RiskIQ: OSINT articles that reference an indicator.'
+        self._taxonomy_predicate = 'Articles'
+        self._taxonomy_valuekey = 'totalrecords'
+        self._config['property'] = 'articles'
+    
+
+
+class Artifacts(IlluminateServiceFile, SuspiciousCount):
+    
+    def __init__(self):
+        super().__init__()
+        self._name = 'RiskIQ_Artifacts'
+        self._description = 'RiskIQ: Illuminate / PassiveTotal project artifacts that match an indicator.'
+        self._taxonomy_predicate = 'Artifacts'
+        self._taxonomy_level = 'suspicious'
+        self._taxonomy_valuekey = 'totalrecords'
+        self._config['property'] = 'artifacts' 
+
+
+
+class Certificates(IlluminateServiceFile):
+    
+    def __init__(self):
+        super().__init__()
+        self._name = 'RiskIQ_Certificates'
+        self._description = 'RiskIQ: SSL/TLS certificates associated with an indicator.'
+        self._taxonomy_predicate = 'Certificates'
+        self._taxonomy_level = 'info'
+        self._taxonomy_valuekey = 'totalrecords'
+        self._config['property'] = 'certificates'
+
+
+
+class Components(IlluminateServiceFile):
+    
+    def __init__(self):
+        super().__init__()
+        self._name = 'RiskIQ_Components'
+        self._description = 'RiskIQ: web components observed during crawls on a hostname.'
+        self._taxonomy_predicate = 'Components'
+        self._taxonomy_level = 'info'
+        self._taxonomy_valuekey = 'totalrecords'
+        self._config['property'] = 'components'
+
+
+
+class Cookies(IlluminateServiceFile):
+    
+    def __init__(self):
+        super().__init__()
+        self._name = 'RiskIQ_Cookies'
+        self._description = 'RiskIQ: cookies observed during crawls on a hostname.'
+        self._taxonomy_predicate = 'Cookies'
+        self._taxonomy_level = 'info'
+        self._taxonomy_valuekey = 'totalrecords'
+        self._config['property'] = 'cookies'
+
+
+
+class HostpairParents(IlluminateServiceFile):
+    
+    def __init__(self):
+        super().__init__()
+        self._name = 'RiskIQ_HostpairParents'
+        self._description = 'RiskIQ: hosts with a parent web component relationship to an IOC.'
+        self._taxonomy_predicate = 'HostpairParents'
+        self._taxonomy_level = 'info'
+        self._taxonomy_valuekey = 'totalrecords'
+        self._config['property'] = 'hostpair_parents'
+
+
+
+class HostpairChildren(IlluminateServiceFile):
+    
+    def __init__(self):
+        super().__init__()
+        self._name = 'RiskIQ_HostpairChildren'
+        self._description = 'RiskIQ: hosts with a child web component relationship to an IOC.'
+        self._taxonomy_predicate = 'HostpairChildren'
+        self._taxonomy_level = 'info'
+        self._taxonomy_valuekey = 'totalrecords'
+        self._config['property'] = 'hostpair_children'
+
+
+
+class Malware(IlluminateServiceFile):
+    
+    def __init__(self):
+        super().__init__()
+        self._name = 'RiskIQ_Malware'
+        self._description = 'RiskIQ: malware hashes from various sources associated with an IOC.'
+        self._taxonomy_predicate = 'Malware'
+        self._taxonomy_level = 'malicious'
+        self._taxonomy_valuekey = 'totalrecords'
+        self._config['property'] = 'malware'
+
+
+
+class Projects(IlluminateServiceFile):
+    
+    def __init__(self):
+        super().__init__()
+        self._name = 'RiskIQ_Projects'
+        self._description = 'RiskIQ: Illuminate / PassiveTotal projects that contain an artifact which matches an IOC.'
+        self._taxonomy_predicate = 'Projects'
+        self._taxonomy_level = 'suspicious'
+        self._taxonomy_valuekey = 'totalrecords'
+        self._config['property'] = 'projects'
+
+
+
+class Resolutions(IlluminateServiceFile):
+    
+    def __init__(self):
+        super().__init__()
+        self._name = 'RiskIQ_Resolutions'
+        self._description = 'RiskIQ: PDNS resolutions for an IOC.'
+        self._taxonomy_predicate = 'Resolutions'
+        self._taxonomy_level = 'info'
+        self._taxonomy_valuekey = 'totalrecords'
+        self._config['property'] = 'resolutions'
+
+
+class Trackers(IlluminateServiceFile):
+    
+    def __init__(self):
+        super().__init__()
+        self._name = 'RiskIQ_Trackers'
+        self._description = 'RiskIQ: trackers observed during a crawl on a host.'
+        self._taxonomy_predicate = 'Trackers'
+        self._taxonomy_level = 'info'
+        self._taxonomy_valuekey = 'totalrecords'
+        self._config['property'] = 'trackers'
+
+
+
+class Services(IlluminateServiceFile):
+    
+    def __init__(self):
+        super().__init__()
+        self._name = 'RiskIQ_Services'
+        self._description = 'RiskIQ: services observed on an IP address.'
+        self._dataTypeList = ['ip']
+        self._taxonomy_predicate = 'Services'
+        self._taxonomy_level = 'info'
+        self._taxonomy_valuekey = 'totalrecords'
+        self._config['property'] = 'services'
+
+
+
+SERVICES = {
+    'artifacts': Artifacts,
+    'articles': Articles,
+    'certificates': Certificates,
+    'components': Components,
+    'cookies': Cookies,
+    'hostpair_parents': HostpairParents,
+    'hostpair_children': HostpairChildren,
+    'malware': Malware,
+    'projects': Projects,
+    'reputation': Reputation,
+    'resolutions': Resolutions,
+    'services': Services,
+    'trackers': Trackers,
+    'summary': Summary,
+    'whois': Whois,
+}
+
+
+if __name__ == '__main__':
+    import argparse
+    import subprocess
+
+    parser = argparse.ArgumentParser()
+    cmdgroup = parser.add_mutually_exclusive_group()
+    cmdgroup.add_argument('--generate', dest='cmd', action='store_const', const='generate',
+                          help='Generate service files for each service.')
+    cmdgroup.add_argument('--test', dest='cmd', action='store_const',const='test',
+                          help='Test a service')
+    parser.add_argument('--property', choices=SERVICES.keys(),
+                        help='Analyzer object property to test.')
+    parser.add_argument('--input',
+                        help='Input value of the IOC to test.')
+    parser.add_argument('--type', choices=['fqdn','domain','ip'],
+                        help='TheHive type of the IOC to test.')
+    parser.add_argument('--username',
+                        help='API username; will be read from passivetotal lib if not provided')
+    parser.add_argument('--apikey',
+                        help='API key; will be read from passivetotal lib if not provided')
+    parser.add_argument('--days-back', default=180, type=int,
+                        help='Number of days back to search.')
+    args = parser.parse_args()
+
+    if args.cmd is None:
+        parser.print_help()
+        exit(1)
+
+    if args.cmd == 'generate':
+        if args.property is not None:
+            SERVICES[args.property]().generate()
+        else:
+            for svc in SERVICES.values():
+                svc().generate()
+        exit(0)
+    
+    if args.cmd == 'test':
+        if args.property is None:
+            print('Property (--property) is required for a test')
+            exit(1)
+        if args.input is None:
+            print('Input value (--input) is required for a test')
+            exit(1)
+        if args.type is None:
+            print('Input type (--type) is required for a test')
+        if args.username is None or args.apikey is None:
+            from passivetotal.libs.account import AccountClient
+            client = AccountClient.from_config()
+        username = client.username if args.username is None else args.username
+        apikey = client.api_key if args.apikey is None else args.apikey
+        test = {
+            "data": args.input,
+            "dataType": args.type,
+            "tlp":0,
+            "config":{
+                "key":"1234567890abcdef",
+                "max_tlp":3,
+                "check_tlp":True,
+                "property":args.property,
+                "days_back": args.days_back,
+                "username": username,
+                "api_key": apikey,
+                "service": 'RiskIQ_{}'.format(args.property.title()),
+            }
+        }
+        result = subprocess.run(
+            ['python3','_analyzer.py'], 
+            input=json.dumps(test),
+            stdout=subprocess.PIPE,
+            text=True
+        )
+        print(result.stdout)
+
+    

--- a/analyzers/RiskIQ/requirements.txt
+++ b/analyzers/RiskIQ/requirements.txt
@@ -1,0 +1,2 @@
+cortexutils
+passivetotal

--- a/analyzers/RiskIQ/requirements.txt
+++ b/analyzers/RiskIQ/requirements.txt
@@ -1,2 +1,2 @@
 cortexutils
-passivetotal
+passivetotal>=2.5.0

--- a/responders/RiskIQ/RiskIQ_PushArtifactToProject.json
+++ b/responders/RiskIQ/RiskIQ_PushArtifactToProject.json
@@ -1,0 +1,62 @@
+{
+  "author": "RiskIQ",
+  "baseConfig": "RiskIQ",
+  "command": "RiskIQ/_responder.py",
+  "config": {
+    "service": "PushArtifactToProject"
+  },
+  "configurationItems": [
+    {
+      "description": "API username of the RiskIQ Illuminate or PassiveTotal account (usually an email address)",
+      "multi": false,
+      "name": "username",
+      "required": true,
+      "type": "string"
+    },
+    {
+      "description": "API key of the RiskIQ Illuminate or PassiveTotal account",
+      "multi": false,
+      "name": "api_key",
+      "required": true,
+      "type": "string"
+    },
+    {
+      "defaultValue": "analyst",
+      "description": "Visiblity for new RiskIQ Illuminate projects (analyst, team, or public).",
+      "multi": false,
+      "name": "project_visibility",
+      "required": true,
+      "type": "string"
+    },
+    {
+      "defaultValue": "Hive:",
+      "description": "Prefix to add when auto-generating project names from case names.",
+      "multi": false,
+      "name": "project_prefix",
+      "required": false,
+      "type": "string"
+    },
+    {
+      "description": "Tag to apply to artifact in TheHive when is has been pushed to a RiskIQ Illuminate Project (leave blank to skip tagging).",
+      "multi": false,
+      "name": "thehive_artifact_tag",
+      "required": false,
+      "type": "string"
+    },
+    {
+      "description": "Tag to apply to artifact in RiskIQ Illuminate when is has been pushed to an Illuminate Project (leave blank to skip tagging).",
+      "multi": false,
+      "name": "riq_artifact_tag",
+      "required": false,
+      "type": "string"
+    }
+  ],
+  "dataTypeList": [
+    "thehive:case_artifact"
+  ],
+  "description": "Push a case to a RiskIQ Illuminate project.",
+  "license": "AGPL-V3",
+  "name": "RiskIQ_PushArtifactToProject",
+  "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
+  "version": "1.0"
+}

--- a/responders/RiskIQ/_responder.py
+++ b/responders/RiskIQ/_responder.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+ 
+
+from cortexutils.responder import Responder
+from _services import SERVICES
+
+
+
+class RiskIQIlluminate(Responder):
+    def __init__(self):
+        Responder.__init__(self)
+        self._username = self.get_param('config.username', None, 'RiskIQ Illuminate username is missing')
+        self._api_key = self.get_param('config.api_key', None, 'RiskIQ Illuminate api_key is missing')
+        self._service_name = self.get_param('config.service', None, 'Service name is required')
+        self._project_visibility = self.get_param('config.project_visiblity','analyst')
+        self._project_prefix = self.get_param('config.project_prefix', 'Hive:')
+        self._thehive_artifact_tag = self.get_param('config.thehive_artifact_tag',None)
+        self._riq_artifact_tag = self.get_param('config.riq_artifact_tag',None)
+        self._service = SERVICES[self._service_name](
+            visibility = self._project_visibility,
+            prefix = self._project_prefix,
+            thehive_artifact_tag = self._thehive_artifact_tag,
+            riq_artifact_tag = self._riq_artifact_tag,
+            username = self._username,
+            api_key = self._api_key
+        )
+    
+    def run(self):
+        Responder.run(self)
+        self._service.run(self.get_param('data'))
+        report = self._service.get_report()
+        if 'error' in report:
+            self.error(report['error'])
+        self.report(report)
+
+    def operations(self, raw):
+        ops = []
+        for op in self._service.get_operations():
+            ops.append(self.build_operation(op['name'], **op['kwargs']))
+        return ops
+
+
+
+if __name__ == '__main__':
+    RiskIQIlluminate().run()

--- a/responders/RiskIQ/_services.py
+++ b/responders/RiskIQ/_services.py
@@ -1,0 +1,194 @@
+import json
+from passivetotal import ProjectsRequest, ArtifactsRequest
+
+
+class IlluminateServiceFile():
+    """Base service class for all RiskIQ service files."""
+
+    def __init__(self, **kwargs):
+        self._name = 'RiskIQ_{}'.format(self.__class__.__name__)
+        self._version = '1.0'
+        self._author = 'RiskIQ'
+        self._url = 'https://github.com/TheHive-Project/Cortex-Analyzers'
+        self._license = 'AGPL-V3'
+        self._command = 'RiskIQ/_responder.py'
+        self._baseconfig = 'RiskIQ'
+        self._description = ''
+        self._dataTypeList = []
+        self._config = { 'service': self.__class__.__name__ }
+        self._report = {}
+        self._operations = []
+        self._params = kwargs
+        self._configitems = [
+            {
+                'name': 'username',
+                'description': 'API username of the RiskIQ Illuminate or PassiveTotal account (usually an email address)',
+                'type': 'string',
+                'multi': False,
+                'required': True
+            },
+            {
+                'name': 'api_key',
+                'description': 'API key of the RiskIQ Illuminate or PassiveTotal account',
+                'type': 'string',
+                'multi': False,
+                'required': True
+            },
+            {
+                'name': 'project_visibility',
+                'description': 'Visiblity for new RiskIQ Illuminate projects (analyst, team, or public).',
+                'type': 'string',
+                'multi': False,
+                'required': True,
+                'defaultValue': 'analyst'
+            },
+            {
+                'name': 'project_prefix',
+                'description': 'Prefix to add when auto-generating project names from case names.',
+                'type': 'string',
+                'multi': False,
+                'required': False,
+                'defaultValue': 'Hive:'
+            },
+            {
+                'name': 'thehive_artifact_tag',
+                'description': 'Tag to apply to artifact in TheHive when is has been pushed to a RiskIQ Illuminate Project (leave blank to skip tagging).',
+                'type': 'string',
+                'multi': False,
+                'required': False
+            },
+            {
+                'name': 'riq_artifact_tag',
+                'description': 'Tag to apply to artifact in RiskIQ Illuminate when is has been pushed to an Illuminate Project (leave blank to skip tagging).',
+                'type': 'string',
+                'multi': False,
+                'required': False
+            }
+        ]
+    
+    def generate(self):
+        """Creates and writes a JSON file to the local directory describing this service."""
+        obj = {
+            'name': self._name,
+            'version': self._version,
+            'author': self._author,
+            'url': self._url,
+            'license': self._license,
+            'description': self._description,
+            'dataTypeList': self._dataTypeList,
+            'command': self._command,
+            'baseConfig': self._baseconfig,
+            'config': self._config,
+            'configurationItems': self._configitems,
+        }
+        filename = '{}.json'.format(self._name)
+        with open(filename, 'w') as f:
+            json.dump(obj, f, indent=2, sort_keys=True)
+    
+    def add_operation(self, opname, **kwargs):
+        self._operations.append({ 'name': opname, 'kwargs': kwargs})
+    
+    def run(self, input):
+        return
+    
+    def get_report(self):
+        return self._report
+
+    def get_operations(self):
+        return self._operations
+    
+
+
+class PushArtifactToProject(IlluminateServiceFile):
+
+    CUSTOMFIELD = 'riq-project-guid'
+    
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._description = 'Push a case to a RiskIQ Illuminate project.'
+        self._dataTypeList = ["thehive:case_artifact"]
+    
+    def run(self, data):
+        project_name = '{0}Case #{1} - {2}'.format(
+            self._params.get('prefix',''), 
+            data['case']['caseId'],
+            data['case']['title']
+        )
+        self._report['case'] = data['case']
+        project_description = data['case'].get('description','')
+        project_visibility = self._params['visibility']
+        request = ProjectsRequest(username=self._params['username'], api_key=self._params['api_key'])
+        projects = request.find_projects(project_name, visibility=project_visibility)
+        if len(projects) > 1:
+            self._report['error'] = 'Found more than one project with the same name'
+            return
+        if len(projects) == 0:
+            project = request.create_project(project_name, visibility=project_visibility, description=project_description)
+            self._report['riq_project'] = project
+        else:
+            project = projects[0]
+        project_guid = project['guid']
+        request = ArtifactsRequest(username=self._params['username'], api_key=self._params['api_key'])
+        artifact_tag = self._params.get('riq_artifact_tag')
+        if artifact_tag is not None:
+            tags = [artifact_tag]
+        else:
+            tags = None
+        self._report['riq_artifact'] = request.upsert_artifact(project_guid, data['data'], tags=tags)
+        thehive_artifact_tag = self._params.get('thehive_artifact_tag')
+        if thehive_artifact_tag is not None:
+            if thehive_artifact_tag not in data['tags']:
+                self.add_operation('AddTagToArtifact', tag=thehive_artifact_tag)
+        #self._report['ops'] = self._operations
+
+
+    
+    
+
+
+
+SERVICES = {
+    'PushArtifactToProject': PushArtifactToProject,
+}
+
+
+if __name__ == '__main__':
+    import argparse
+    import subprocess
+
+    parser = argparse.ArgumentParser()
+    cmdgroup = parser.add_mutually_exclusive_group()
+    cmdgroup.add_argument('--generate', dest='cmd', action='store_const', const='generate',
+                          help='Generate service files for each service.')
+    cmdgroup.add_argument('--test', dest='cmd', action='store_const',const='test',
+                          help='Test a service')
+    parser.add_argument('--responder', choices=SERVICES.keys(),
+                        help='Responder to test.')
+    parser.add_argument('--input',
+                        help='Input value of the IOC to test.')
+    parser.add_argument('--type', choices=['fqdn','domain','ip'],
+                        help='TheHive type of the IOC to test.')
+    parser.add_argument('--username',
+                        help='API username; will be read from passivetotal lib if not provided')
+    parser.add_argument('--apikey',
+                        help='API key; will be read from passivetotal lib if not provided')
+    parser.add_argument('--days-back', default=180, type=int,
+                        help='Number of days back to search.')
+    args = parser.parse_args()
+
+    if args.cmd is None:
+        parser.print_help()
+        exit(1)
+
+    if args.cmd == 'generate':
+        if args.responder is not None:
+            SERVICES[args.responder]().generate()
+        else:
+            for svc in SERVICES.values():
+                svc().generate()
+        exit(0)
+    
+    if args.cmd == 'test':
+        print('Sorry, testing responders is not yet implemented.')
+
+    

--- a/responders/RiskIQ/requirements.txt
+++ b/responders/RiskIQ/requirements.txt
@@ -1,0 +1,2 @@
+cortexutils
+passivetotal

--- a/thehive-templates/RiskIQ_Articles_1_0/long.html
+++ b/thehive-templates/RiskIQ_Articles_1_0/long.html
@@ -1,0 +1,47 @@
+<div class="report-PT" ng-if="success">
+    <style>
+        .report-PT dl {
+            margin-bottom: 2px;
+        }
+        .label {
+            margin-right: 1em;
+        }
+    </style>
+
+
+    <div class="panel panel-info">
+        <div class="panel-body">
+            <div ng-if="content.records.length === 0">
+                No articles available for this IOC.
+            </div>
+            <div ng-if="content.records.length !== 0" class="panel panel-warning">
+                <div class="panel-heading">
+                    <strong>RiskIQ OSINT Articles</strong>
+                </div>
+                <div class="panel-body">
+                    <div class="panel" ng-repeat="art in content.records">
+                        <div class="panel-body">
+                            <h3>{{art.title}}</h3>
+                            <p>
+                                <span class="label label-primary" ng-repeat="tag in art.tags">{{tag}}</span>
+                            </p>
+                            <p><i>Published {{art.date_published}} ({{art.type}})</i></p>
+                            <p>{{art.summary}}</p>
+                            
+                        
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="panel panel-danger" ng-if="!success">
+    <div class="panel-heading">
+        <strong>{{(artifact.data || artifact.attachment.name) | fang}}</strong>
+    </div>
+    <div class="panel-body">
+        {{content.errorMessage}}
+    </div>
+</div>

--- a/thehive-templates/RiskIQ_Artifacts_1_0/long.html
+++ b/thehive-templates/RiskIQ_Artifacts_1_0/long.html
@@ -1,0 +1,81 @@
+<div class="report-PT" ng-if="success">
+    <style>
+        .report-PT dl {
+            margin-bottom: 2px;
+        }
+        .collabel {
+            color: #777;    
+        }
+        .colvalue {
+            font-weight: 600;
+        }
+        .label {
+            margin-right: 5px;
+        }
+    </style>
+
+
+    <div class="panel panel-info">
+        <div class="panel-body">
+            <div ng-if="content.records.length === 0">
+                No RiskIQ artifacts reference this IOC.
+            </div>
+            <div ng-if="content.records.length !== 0" class="panel panel-default">
+                <div class="panel-heading">
+                    <strong>RiskIQ Artifacts</strong>
+                </div>
+                <div class="panel-body">
+                    <div class="panel panel-info" ng-repeat="art in content.records">
+                        <div class="panel-body">
+                            <div class="row">
+                                <div class="col-xs-12 collabel">Project GUID</div>
+                                <div class="col-xs-12 colvalue">{{art.project_guid}}</div>
+                            </div>
+                            <div class="row">
+                                <div class="col-xs-12 collabel">Article GUID</div>
+                                <div class="col-xs-12 colvalue">{{art.artifact_guid}}</div>
+                            </div>
+                            <div class="row">
+                                <div class="col-xs-6 collabel">Is monitored?</div>
+                                <div class="col-xs-6 collabel">Created</div>
+                            </div>
+                            <div class="row">
+                                <div class="col-xs-6 colvalue">{{art.is_monitored}}</div>
+                                <div class="col-xs-6 colvalue">{{art.created}}</div>
+                            </div>
+                            <div class="row">
+                                <div class="col-xs-6 collabel">Owner</div>
+                                <div class="col-xs-6 collabel">Creator</div>
+                            </div>
+                            <div class="row">
+                                <div class="col-xs-6 colvalue">{{art.owner}}</div>
+                                <div class="col-xs-6 colvalue">{{art.creator}}</div>
+                            </div>
+                            <div class="row">
+                                <div class="col-xs-6 collabel">User Tags</div>
+                                <div class="col-xs-6 collabel">Global Tags</div>
+                            </div>
+                            <div class="row">
+                                <div class="col-xs-6">
+                                    <span class="label label-default" ng-repeat="tag in art.tags_user">{{tag}}</span>
+                                </div>
+                                <div class="col-xs-6">
+                                    <span class="label label-default" ng-repeat="tag in art.tags_global">{{tag}}</span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="panel panel-danger" ng-if="!success">
+    <div class="panel-heading">
+        <strong>{{(artifact.data || artifact.attachment.name) | fang}}</strong>
+    </div>
+    <div class="panel-body">
+        {{content.errorMessage}}
+    </div>
+</div>

--- a/thehive-templates/RiskIQ_Certificates_1_0/long.html
+++ b/thehive-templates/RiskIQ_Certificates_1_0/long.html
@@ -1,0 +1,96 @@
+<div class="report-PT" ng-if="success">
+    <style>
+        .report-PT dl {
+            margin-bottom: 2px;
+        }
+        .fieldlabel {
+            font-size: 10pt;
+            color: #777;
+        }
+        .fieldvalue {
+            font-weight: 600;
+            margin-bottom: 5px;
+        }
+    </style>
+
+
+    <div class="panel panel-info">
+        <div class="panel-body">
+            <div ng-if="content.records.length === 0">
+                No certificates available for this IOC.
+            </div>
+            <div ng-if="content.records.length !== 0" class="panel panel-default">
+                <div class="panel-heading">
+                    <strong>RiskIQ TLS/SSL Certificates</strong>
+                </div>
+                <div class="panel-body">
+                    <div class="panel" ng-repeat="cert in content.records">
+                        <div class="panel-body">
+                            <div class="row">
+                                <div class="panel panel-info">
+                                    <div class="panel-heading"><strong>Certificate</strong></div>
+                                    <div class="panel-body">
+                                        <div ng-repeat="(key,value) in cert">
+                                            <div ng-if="((key | limitTo : 6) !== 'issuer') && ((key | limitTo : 7) !== 'subject') " class="col-xs-6">
+                                                <div class='fieldlabel'>{{key}}</div>
+                                                <div class='fieldvalue'>
+                                                    <span ng-if="value!==''">{{value}}</span>
+                                                    <span ng-if="value===''" style="padding-left: 10px;">&mdash;</span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-xs-6">
+                                    <div class="panel panel-info">
+                                        <div class="panel-heading"><strong>Subject</strong></div>
+                                        <div class="panel-body">
+                                            <div ng-repeat="(key,value) in cert">
+                                                <div ng-if="(key | limitTo : 7) === 'subject'">
+                                                    <div class='fieldlabel'>{{key|limitTo:50:7}}</div>
+                                                    <div class='fieldvalue'>
+                                                        <span ng-if="value!==''">{{value}}</span>
+                                                        <span ng-if="value===''" style="padding-left: 10px;">&mdash;</span>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-xs-6">
+                                    <div class="panel panel-info">
+                                        <div class="panel-heading"><strong>Issuer</strong></div>
+                                        <div class="panel-body">
+                                            <div ng-repeat="(key,value) in cert">
+                                                <div ng-if="(key | limitTo : 6) === 'issuer'">
+                                                    <div class='fieldlabel'>{{key|limitTo:50:6}}</div>
+                                                    <div class='fieldvalue'>
+                                                        <span ng-if="value!==''">{{value}}</span>
+                                                        <span ng-if="value===''" style="padding-left: 10px;">&mdash;</span>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            
+                        
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="panel panel-danger" ng-if="!success">
+    <div class="panel-heading">
+        <strong>{{(artifact.data || artifact.attachment.name) | fang}}</strong>
+    </div>
+    <div class="panel-body">
+        {{content.errorMessage}}
+    </div>
+</div>

--- a/thehive-templates/RiskIQ_Components_1_0/long.html
+++ b/thehive-templates/RiskIQ_Components_1_0/long.html
@@ -1,0 +1,54 @@
+<div class="report-PT" ng-if="success">
+    <style>
+        .report-PT dl {
+            margin-bottom: 2px;
+        }
+    </style>
+
+
+    <div class="panel panel-info">
+        <div class="panel-body">
+            <div ng-if="content.records.length === 0">
+                No web components available for this IOC.
+            </div>
+            <div ng-if="content.records.length !== 0" class="panel panel-default">
+                <div class="panel-heading">
+                    <strong>RiskIQ Web Components</strong>
+                </div>
+                <div class="panel-body">
+                    <table class="table table-hover table-condensed">
+                        <thead>
+                            <tr>
+                                <th>Category</th>
+                                <th>Component</th>
+                                <th>Version</th>
+                                <th>Host</th>
+                                <th>First Seen</th>
+                                <th>Last Seen</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr ng-repeat="comp in content.records">
+                                <td>{{comp.category}}</td>
+                                <td>{{comp.label}}</td>
+                                <td>{{comp.version}}</td>
+                                <td>{{comp.hostname}}</td>
+                                <td>{{comp.firstseen}}</td>
+                                <td>{{comp.lastseen}}</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="panel panel-danger" ng-if="!success">
+    <div class="panel-heading">
+        <strong>{{(artifact.data || artifact.attachment.name) | fang}}</strong>
+    </div>
+    <div class="panel-body">
+        {{content.errorMessage}}
+    </div>
+</div>

--- a/thehive-templates/RiskIQ_Cookies_1_0/long.html
+++ b/thehive-templates/RiskIQ_Cookies_1_0/long.html
@@ -1,0 +1,83 @@
+<div class="report-PT" ng-if="success">
+    <style>
+        .report-PT dl {
+            margin-bottom: 2px;
+        }
+    </style>
+
+
+    <div class="panel panel-info">
+        <div class="panel-body">
+            <div ng-if="content.records.length === 0">
+                No cookies available for this IOC.
+            </div>
+            <div ng-if="content.records.length !== 0" class="panel panel-default">
+                <div class="panel-heading">
+                    <strong>RiskIQ Host Cookies</strong>
+                </div>
+                <div class="panel-body">
+                    <div class="row">
+                        <div class="col-xs-6">
+                            <div class="panel panel-info">
+                                <div class="panel-heading"><b>Distinct Domains</b></div>
+                                <div class="panel-body">
+                                    <table class="tabel table-condensed">
+                                        <tr ng-repeat="d in content.distinct_domains">
+                                            <td>{{d}}</td>
+                                        </tr>
+                                    </table>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-xs-6">
+                            <div class="panel panel-info">
+                                <div class="panel-heading"><b>Distinct Cookie Names</b></div>
+                                <div class="panel-body">
+                                    <table class="tabel table-condensed">
+                                        <tr ng-repeat="d in content.distinct_names">
+                                            <td>{{d}}</td>
+                                        </tr>
+                                    </table>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="panel panel-info">
+                        <div class="panel-heading"><b>Cookie History</b></div>
+                        <div class="panel-body">
+                            <table class="table table-hover table-condensed">
+                                <thead>
+                                    <tr>
+                                        <th>Cookie Name</th>
+                                        <th>Cookie Domain</th>
+                                        <th>Host</th>
+                                        <th>First Seen</th>
+                                        <th>Last Seen</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr ng-repeat="cook in content.records">
+                                        <td>{{cook.name}}</td>
+                                        <td>{{cook.domain}}</td>
+                                        <td>{{cook.hostname}}</td>
+                                        <td>{{cook.firstseen}}</td>
+                                        <td>{{cook.lastseen}}</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="panel panel-danger" ng-if="!success">
+    <div class="panel-heading">
+        <strong>{{(artifact.data || artifact.attachment.name) | fang}}</strong>
+    </div>
+    <div class="panel-body">
+        {{content.errorMessage}}
+    </div>
+</div>

--- a/thehive-templates/RiskIQ_HostpairChildren_1_0/long.html
+++ b/thehive-templates/RiskIQ_HostpairChildren_1_0/long.html
@@ -1,0 +1,81 @@
+<div class="report-PT" ng-if="success">
+    <style>
+        .report-PT dl {
+            margin-bottom: 2px;
+        }
+    </style>
+
+
+    <div class="panel panel-info">
+        <div class="panel-body">
+            <div ng-if="content.records.length === 0">
+                No child hostpairs available for this IOC.
+            </div>
+            <div ng-if="content.records.length !== 0" class="panel panel-default">
+                <div class="panel-heading">
+                    <strong>RiskIQ Child Hostpairs</strong>
+                </div>
+                <div class="panel-body">
+                    <div class="row">
+                        <div class="col-xs-6">
+                            <div class="panel panel-info">
+                                <div class="panel-heading"><b>Distinct Hosts</b></div>
+                                <div class="panel-body">
+                                    <table class="tabel table-condensed">
+                                        <tr ng-repeat="d in content.distinct_hosts">
+                                            <td>{{d}}</td>
+                                        </tr>
+                                    </table>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-xs-6">
+                            <div class="panel panel-info">
+                                <div class="panel-heading"><b>Distinct Causes</b></div>
+                                <div class="panel-body">
+                                    <table class="tabel table-condensed">
+                                        <tr ng-repeat="d in content.distinct_causes">
+                                            <td>{{d}}</td>
+                                        </tr>
+                                    </table>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="panel panel-info">
+                        <div class="panel-heading"><b>Child Hostpair History</b></div>
+                        <div class="panel-body">
+                            <table class="table table-hover table-condensed">
+                                <thead>
+                                    <tr>
+                                        <th>Cause</th>
+                                        <th>Child</th>
+                                        <th>First Seen</th>
+                                        <th>Last Seen</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr ng-repeat="hp in content.records">
+                                        <td>{{hp.cause}}</td>
+                                        <td>{{hp.child}}</td>
+                                        <td>{{hp.firstseen}}</td>
+                                        <td>{{hp.lastseen}}</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="panel panel-danger" ng-if="!success">
+    <div class="panel-heading">
+        <strong>{{(artifact.data || artifact.attachment.name) | fang}}</strong>
+    </div>
+    <div class="panel-body">
+        {{content.errorMessage}}
+    </div>
+</div>

--- a/thehive-templates/RiskIQ_HostpairParents_1_0/long.html
+++ b/thehive-templates/RiskIQ_HostpairParents_1_0/long.html
@@ -1,0 +1,81 @@
+<div class="report-PT" ng-if="success">
+    <style>
+        .report-PT dl {
+            margin-bottom: 2px;
+        }
+    </style>
+
+
+    <div class="panel panel-info">
+        <div class="panel-body">
+            <div ng-if="content.records.length === 0">
+                No parent hostpairs available for this IOC.
+            </div>
+            <div ng-if="content.records.length !== 0" class="panel panel-default">
+                <div class="panel-heading">
+                    <strong>RiskIQ Parent Hostpairs</strong>
+                </div>
+                <div class="panel-body">
+                    <div class="row">
+                        <div class="col-xs-6">
+                            <div class="panel panel-info">
+                                <div class="panel-heading"><b>Distinct Hosts</b></div>
+                                <div class="panel-body">
+                                    <table class="tabel table-condensed">
+                                        <tr ng-repeat="d in content.distinct_hosts">
+                                            <td>{{d}}</td>
+                                        </tr>
+                                    </table>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-xs-6">
+                            <div class="panel panel-info">
+                                <div class="panel-heading"><b>Distinct Causes</b></div>
+                                <div class="panel-body">
+                                    <table class="tabel table-condensed">
+                                        <tr ng-repeat="d in content.distinct_causes">
+                                            <td>{{d}}</td>
+                                        </tr>
+                                    </table>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="panel panel-info">
+                        <div class="panel-heading"><b>Parent Hostpair History</b></div>
+                        <div class="panel-body">
+                            <table class="table table-hover table-condensed">
+                                <thead>
+                                    <tr>
+                                        <th>Cause</th>
+                                        <th>Parent</th>
+                                        <th>First Seen</th>
+                                        <th>Last Seen</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr ng-repeat="hp in content.records">
+                                        <td>{{hp.cause}}</td>
+                                        <td>{{hp.parent}}</td>
+                                        <td>{{hp.firstseen}}</td>
+                                        <td>{{hp.lastseen}}</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="panel panel-danger" ng-if="!success">
+    <div class="panel-heading">
+        <strong>{{(artifact.data || artifact.attachment.name) | fang}}</strong>
+    </div>
+    <div class="panel-body">
+        {{content.errorMessage}}
+    </div>
+</div>

--- a/thehive-templates/RiskIQ_Malware_1_0/long.html
+++ b/thehive-templates/RiskIQ_Malware_1_0/long.html
@@ -1,0 +1,48 @@
+<div class="report-PT" ng-if="success">
+    <style>
+        .report-PT dl {
+            margin-bottom: 2px;
+        }
+    </style>
+
+
+    <div class="panel panel-info">
+        <div class="panel-body">
+            <div ng-if="content.records.length === 0">
+                No malware hashes found for this IOC.
+            </div>
+            <div ng-if="content.records.length !== 0" class="panel panel-default">
+                <div class="panel-heading">
+                    <strong>RiskIQ Malware Hashes</strong>
+                </div>
+                <div class="panel-body">
+                    <table class="table table-hover table-condensed">
+                        <thead>
+                            <tr>
+                                <th>Hash</th>
+                                <th>Source</th>
+                                <th>Date Collected</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr ng-repeat="mal in content.records">
+                                <td>{{mal.hash}}</td>
+                                <td><a href="{{mal.source_url}}" target="_blank">{{mal.source}}</a></td>
+                                <td>{{mal.date_collected}}</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="panel panel-danger" ng-if="!success">
+    <div class="panel-heading">
+        <strong>{{(artifact.data || artifact.attachment.name) | fang}}</strong>
+    </div>
+    <div class="panel-body">
+        {{content.errorMessage}}
+    </div>
+</div>

--- a/thehive-templates/RiskIQ_Projects_1_0/long.html
+++ b/thehive-templates/RiskIQ_Projects_1_0/long.html
@@ -1,0 +1,80 @@
+<div class="report-PT" ng-if="success">
+    <style>
+        .report-PT dl {
+            margin-bottom: 2px;
+        }
+        .collabel {
+            color: #777;    
+        }
+        .colvalue {
+            font-weight: 600;
+        }
+        .label {
+            margin-right: 5px;
+        }
+    </style>
+
+
+    <div class="panel panel-info">
+        <div class="panel-body">
+            <div ng-if="content.records.length === 0">
+                No projects found that reference this IOC.
+            </div>
+            <div ng-if="content.records.length !== 0" class="panel panel-default">
+                <div class="panel-heading">
+                    <strong>RiskIQ Projects</strong>
+                </div>
+                <div class="panel-body">
+                    <div class="panel panel-info" ng-repeat="proj in content.records">
+                        <div class="panel-heading"><b>{{proj.name}}</b></div>
+                        <div class="panel-body">
+                            <div class="row">
+                                <div class="col-xs-2 collabel text-right">Description</div>
+                                <div class="col-xs-10 colvalue">{{proj.description}}</div>
+                            </div>
+                            <div class="row">
+                                <div class="col-xs-2 collabel text-right">Created</div>
+                                <div class="col-xs-10 colvalue">{{proj.created}}</div>
+                            </div>
+                            <div class="row">
+                                <div class="col-xs-2 collabel text-right">Visibility</div>
+                                <div class="col-xs-10 colvalue">{{proj.visibility}}</div>
+                            </div>
+                            <div class="row">
+                                <div class="col-xs-2 collabel text-right">Tags</div>
+                                <div class="col-xs-10">
+                                    <span class="label label-default" ng-repeat="tag in proj.tags">{{tag}}</span>
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-xs-2 collabel text-right">Owner</div>
+                                <div class="col-xs-10 colvalue">{{proj.owner}}</div>
+                            </div>
+                            <div class="row">
+                                <div class="col-xs-2 collabel text-right">Creator</div>
+                                <div class="col-xs-10 colvalue">{{proj.creator}}</div>
+                            </div>
+                            <div class="row">
+                                <div class="col-xs-2 collabel text-right">Organization</div>
+                                <div class="col-xs-10 colvalue">{{proj.organization}}</div>
+                            </div>
+                            <div class="row">
+                                <div class="col-xs-2 collabel text-right">GUID</div>
+                                <div class="col-xs-10 colvalue">{{proj.project_guid}}</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="panel panel-danger" ng-if="!success">
+    <div class="panel-heading">
+        <strong>{{(artifact.data || artifact.attachment.name) | fang}}</strong>
+    </div>
+    <div class="panel-body">
+        {{content.errorMessage}}
+    </div>
+</div>

--- a/thehive-templates/RiskIQ_Reputation_1_0/long.html
+++ b/thehive-templates/RiskIQ_Reputation_1_0/long.html
@@ -1,0 +1,71 @@
+<div class="report-PT" ng-if="success">
+    <style>
+        .report-PT dl {
+            margin-bottom: 2px;
+        }
+        .progress {
+            border: 1px solid #CCC;
+            height: 27px;
+        }
+        .progress-bar {
+            font-size: 16px;
+            line-height: 25px;
+        }
+    </style>
+
+
+    <div class="panel panel-info">
+        <div class="panel-body">
+            <div ng-if="content.result.length === 0">
+                No Reputation Score available for this IOC.
+            </div>
+            <div ng-if="content.result.length !== 0" class="panel panel-{{content.uicontext}}">
+                <div class="panel-heading">
+                    <strong>RiskIQ Illuminate Reputation Score</strong>
+                </div>
+                <div class="panel-body">
+                    <dl class="dl-horizontal">
+                        <dt>Score:</dt>
+                        <dd>
+                            <div class="progress">
+                                <div class="progress-bar progress-bar-{{content.uicontext}}" role="progressbar" aria=valuenow="{{content.score}}" aria-valuemin="0" aria-valuemax="100" style="width: {{content.score}}%;">
+                                    <b>{{content.score}}</b> / 100 ({{content.classification}})
+                                </div>
+                            </div>
+                        </dd>
+                    </dl>
+                </div>
+            </div>
+            <div ng-if="content.result.length !== 0" class="panel panel-default">
+                <div class="panel-heading">
+                    Score Justification
+                </div>
+                <div class="panel-body">
+                    <table class="table table-sm" ng-if="content.rules.length > 0">
+                        <tr>
+                            <th>Severity</th>
+                            <th>Name</th>
+                            <th>Description</th>
+                        </tr>
+                        <tr ng-repeat="r in content.rules">
+                            <td><span class="label label-{{r.uicontext}}">{{r.severity}}</span></td>
+                            <td>{{r.name || 'None'}}</td>
+                            <td>{{r.description || 'None'}}</td>
+                        </tr>
+                    </table>
+                </div>
+            </div>
+
+        </div>
+    </div>
+
+</div>
+
+<div class="panel panel-danger" ng-if="!success">
+    <div class="panel-heading">
+        <strong>{{(artifact.data || artifact.attachment.name) | fang}}</strong>
+    </div>
+    <div class="panel-body">
+        {{content.errorMessage}}
+    </div>
+</div>

--- a/thehive-templates/RiskIQ_Resolutions_1_0/long.html
+++ b/thehive-templates/RiskIQ_Resolutions_1_0/long.html
@@ -1,0 +1,87 @@
+<div class="report-PT" ng-if="success">
+    <style>
+        .report-PT dl {
+            margin-bottom: 2px;
+        }
+        .fieldlabel {
+            font-size: 10pt;
+            color: #777;
+        }
+        .fieldvalue {
+            font-weight: 600;
+            margin-bottom: 5px;
+        }
+    </style>
+
+
+    <div class="panel panel-info">
+        <div class="panel-body">
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <strong>RiskIQ PDNS Resolutions</strong>
+                </div>
+                <div class="panel-body">
+                    <div class="panel panel-default">
+                        <div class="panel-body">
+                            <div class="row">
+                                <div class="col-xs-4">
+                                    <div class="fieldlabel">Earliest Available Record</div>
+                                    <div class="fieldvalue">{{content.firstseen}}</div>
+                                </div>
+                                <div class="col-xs-4">
+                                    <div class="fieldlabel">Most Recent Record</div>
+                                    <div class="fieldvalue">{{content.lastseen}}</div>
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-xs-4">
+                                    <div class="fieldlabel">Query Start Date</div>
+                                    <div class="fieldvalue">{{content.datestart}}</div>
+                                </div>
+                                <div class="col-xs-4">
+                                    <div class="fieldlabel">Query End Date</div>
+                                    <div class="fieldvalue">{{content.dateend}}</div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="panel panel-info">
+                        <div class="panel-heading"><b>pDNS Resolution History</b></div>
+                        <div class="panel-body">
+                            <table class="table table-hover table-condensed">
+                                <thead>
+                                    <tr>
+                                        <th>Type</th>
+                                        <th>Resolution</th>
+                                        <th>First Seen</th>
+                                        <th>Last Seen</th>
+                                        <th>Sources</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr ng-repeat="p in content.records">
+                                        <td class="text-nowrap">{{p.recordtype}}</td>
+                                        <td>{{p.resolve}}</td>
+                                        <td class="text-nowrap">{{p.firstseen}}</td>
+                                        <td class="text-nowrap">{{p.lastseen}}</td>
+                                        <td>
+                                            <span class="text-muted" style="margin-right: 10px;" ng-repeat="s in p.sources">{{s}}</span></td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="panel panel-danger" ng-if="!success">
+    <div class="panel-heading">
+        <strong>{{(artifact.data || artifact.attachment.name) | fang}}</strong>
+    </div>
+    <div class="panel-body">
+        {{content.errorMessage}}
+    </div>
+</div>

--- a/thehive-templates/RiskIQ_Services_1_0/long.html
+++ b/thehive-templates/RiskIQ_Services_1_0/long.html
@@ -1,0 +1,175 @@
+<div class="report-PT" ng-if="success">
+    <style>
+        .report-PT dl {
+            margin-bottom: 2px;
+        }
+        .fieldlabel {
+            font-size: 10pt;
+            color: #777;
+        }
+        .fieldvalue {
+            font-weight: 600;
+            margin-bottom: 5px;
+        }
+        .svctitle {
+            font-size: 18px;
+        }
+        .modal-content {
+            border: 1px solid #999;
+            border: 1px solid rgba(0,0,0,.2);
+            border-radius: 6px;
+            -webkit-box-shadow: 0 3px 9px rgb(0 0 0 / 50%);
+            box-shadow: 0 3px 9px rgb(0 0 0 / 50%);
+            outline: 0;
+        }
+    </style>
+
+
+    <div class="panel panel-info">
+        <div class="panel-body">
+            <div ng-if="content.records.length === 0">
+                No service history available for this IOC.
+            </div>
+            <div ng-if="content.records.length !== 0" class="panel panel-default">
+                <div class="panel-heading">
+                    <strong>RiskIQ Services</strong>
+                </div>
+                <div class="panel-body">
+                    <div class="panel panel-info" ng-repeat="svc in content.records">
+                        <div class="panel-heading svctitle"><strong>{{svc.protocol}} {{svc.port}}</strong> <i>({{svc.status}})</i>
+                        </div>
+                        <div class="panel-body">
+                            <div class="row">
+                                <div class="col-xs-4 fieldlabel">First Seen</div>
+                                <div class="col-xs-4 fieldlabel">Last Seen</div>
+                                <div class="col-xs-4 fieldlabel">Observations</div>
+                            </div>
+                            <div class="row">
+                                <div class="col-xs-4 fieldvalue">{{svc.firstseen}}</div>
+                                <div class="col-xs-4 fieldvalue">{{svc.lastseen}}</div>
+                                <div class="col-xs-4 fieldvalue">{{svc.count}}</div>
+                            </div>
+                            <div class="row" ng-if="svc.current_services.length !== 0">
+                                <hr/>
+                                <div class="col-xs-12 fieldlabel">Current Services</div>
+                            </div>
+                            <div class="panel" ng-if="svc.current_services.length !== 0">
+                                <div class="panel-body">
+                                    <table class="table table-condensed">
+                                        <thead>
+                                            <tr>
+                                                <th>Service</th>
+                                                <th>Category</th>
+                                                <th>Version</th>
+                                                <th>First Seen</th>
+                                                <th>Last Seen</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            <tr ng-repeat="s in svc.current_services">
+                                                <td>{{s.label}}</td>
+                                                <td>{{s.category}}</td>
+                                                <td>{{s.version}}</td>
+                                                <td>{{s.firstSeen}}</td>
+                                                <td>{{s.lastSeen}}</td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </div>
+                            
+                            <div class="row" ng-if="svc.banners.length !== 0">
+                                <hr/>
+                                <div class="col-xs-12 fieldlabel">Banners</div>
+                            </div>
+                            <div class="panel" ng-if="svc.banners.length !== 0">
+                                <div class="panel-body">
+                                    <table class="table table-condensed">
+                                        <thead>
+                                            <tr>
+                                                <th>Scan Type</th>
+                                                <th>Observations</th>
+                                                <th>First Seen</th>
+                                                <th>Last Seen</th>
+                                                <th>Banners</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            <tr ng-repeat="b in svc.banners">
+                                                <td>{{b.scanType}}</td>
+                                                <td>{{b.count}}</td>
+                                                <td>{{b.firstSeen}}</td>
+                                                <td>{{b.lastSeen}}</td>
+                                                <td><button type="button" class="btn btn-secondary btn-sm" data-toggle="modal" data-target="#b{{svc.protocol}}{{svc.port}}{{b.scanType}}">View</button>
+                                                    <div 
+                                                        class="modal" 
+                                                        id="b{{svc.protocol}}{{svc.port}}{{b.scanType}}" 
+                                                        role="dialog" 
+                                                        aria-labeledby="b{{svc.protocol}}{{svc.port}}{{b.scanType}}label" >
+                                                        <div class="modal-dialog modal-lg" role="document">
+                                                            <div class="modal-content">
+                                                                <div class="modal-header">
+                                                                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                                                                    <h4 class="modal-title" id="b{{svc.protocol}}{{svc.port}}{{b.scanType}}label">{{svc.protocol}} {{svc.port}} Banners via {{b.scanType}} from {{b.firstSeen}} to {{b.lastSeen}}</h4>
+                                                                </div>
+                                                                <div class="modal-body">
+                                                                    <pre class="pre-scrollable">{{b.banner}}</pre>
+                                                                </div>
+                                                                <div class="modal-footer">
+                                                                    <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                                                                </div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                
+                                                </td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </div>
+                            
+                            <div class="row" ng-if="svc.recent_services.length !== 0">
+                                <hr/>
+                                <div class="col-xs-12 fieldlabel">Recent Services</div>
+                            </div>
+                            <div class="panel" ng-if="svc.recent_services.length !== 0">
+                                <div class="panel-body">
+                                    <table class="table table-condensed">
+                                        <thead>
+                                            <tr>
+                                                <th>Service</th>
+                                                <th>Category</th>
+                                                <th>Version</th>
+                                                <th>First Seen</th>
+                                                <th>Last Seen</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody>
+                                            <tr ng-repeat="s in svc.recent_services">
+                                                <td>{{s.label}}</td>
+                                                <td>{{s.category}}</td>
+                                                <td>{{s.version}}</td>
+                                                <td>{{s.firstSeen}}</td>
+                                                <td>{{s.lastSeen}}</td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="panel panel-danger" ng-if="!success">
+    <div class="panel-heading">
+        <strong>{{(artifact.data || artifact.attachment.name) | fang}}</strong>
+    </div>
+    <div class="panel-body">
+        {{content.errorMessage}}
+    </div>
+</div>

--- a/thehive-templates/RiskIQ_Subdomains_1_0/long.html
+++ b/thehive-templates/RiskIQ_Subdomains_1_0/long.html
@@ -1,0 +1,69 @@
+<div class="report-PT" ng-if="success">
+    <style>
+        .report-PT dl {
+            margin-bottom: 2px;
+        }
+        .fieldlabel {
+            font-size: 10pt;
+            color: #777;
+        }
+        .fieldvalue {
+            font-weight: 600;
+            margin-bottom: 5px;
+            margin
+        }
+    </style>
+
+
+    <div class="panel panel-info">
+        <div class="panel-body">
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <strong>RiskIQ Subdomains</strong>
+                </div>
+                <div class="panel-body">
+                    <div class="panel panel-default">
+                        <div class="panel-body">
+                            <div class="row">
+                                <div class="col-xs-4">
+                                    <div class="fieldlabel">Primary Domain</div>
+                                    <div class="fieldvalue">{{content.primary_domain}}</div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="panel panel-info">
+                        <div class="panel-heading"><b>Observed Subdomains</b></div>
+                        <div class="panel-body">
+                            <table class="table table-hover table-condensed">
+                                <thead>
+                                    <tr>
+                                        <th>Subdomain</th>
+                                        <th>Primary Domain</th>
+                                        <th>FQDN</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr ng-repeat="p in content.records">
+                                        <td class="text-nowrap">{{p.subdomain}}</td>
+                                        <td>{{p.primary_domain}}</td>
+                                        <td class="text-nowrap">{{p.hostname}}</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="panel panel-danger" ng-if="!success">
+    <div class="panel-heading">
+        <strong>{{(artifact.data || artifact.attachment.name) | fang}}</strong>
+    </div>
+    <div class="panel-body">
+        {{content.errorMessage}}
+    </div>
+</div>

--- a/thehive-templates/RiskIQ_Summary_1_0/long.html
+++ b/thehive-templates/RiskIQ_Summary_1_0/long.html
@@ -1,0 +1,129 @@
+<div class="report-PT" ng-if="success">
+    <style>
+        .report-PT dl {
+            margin-bottom: 2px;
+        }
+    </style>
+
+
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <strong>RiskIQ Illuminate Available Datasets</strong>
+        </div>
+        <div class="panel-body">
+            <div class="row">
+                <div class="col-md-2">
+                    <div class="panel panel-{{ content.resolutions==0 ? 'default' : 'info' }}">
+                        <div class="panel-heading text-center">
+                            pDNS
+                        </div>
+                        <div class="panel-body text-center">
+                            <h3>{{content.resolutions}}</h3>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-2">
+                    <div class="panel panel-{{ content.certificates==0 ? 'default' : 'info' }}">
+                        <div class="panel-heading text-center">
+                            TLS/SSL
+                        </div>
+                        <div class="panel-body text-center">
+                            <h3>{{content.certificates}}</h3>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-2">
+                    <div class="panel panel-{{ content.articles==0 ? 'default' : 'danger' }} ">
+                        <div class="panel-heading text-center">
+                            Articles
+                        </div>
+                        <div class="panel-body text-center">
+                            <h3>{{content.articles}}</h3>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-2">
+                    <div class="panel panel-{{ content.projects==0 ? 'default' : 'warning' }} ">
+                        <div class="panel-heading text-center">
+                            Projects
+                        </div>
+                        <div class="panel-body text-center">
+                            <h3>{{content.projects}}</h3>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-2">
+                    <div class="panel panel-{{ content.malware_hashes==0 ? 'default' : 'danger' }} ">
+                        <div class="panel-heading text-center">
+                            Malware
+                        </div>
+                        <div class="panel-body text-center">
+                            <h3>{{content.malware_hashes}}</h3>
+                        </div>
+                    </div>
+                </div>
+                <div ng-if="content.trackers" class="col-md-2">
+                    <div class="panel panel-{{ content.trackers==0 ? 'default' : 'info' }} ">
+                        <div class="panel-heading text-center">
+                            Trackers
+                        </div>
+                        <div class="panel-body text-center">
+                            <h3>{{content.trackers}}</h3>
+                        </div>
+                    </div>
+                </div>
+                <div ng-if="content.components"  class="col-md-2">
+                    <div class="panel panel-{{ content.components==0 ? 'default' : 'info' }} ">
+                        <div class="panel-heading text-center">
+                            Components
+                        </div>
+                        <div class="panel-body text-center">
+                            <h3>{{content.components}}</h3>
+                        </div>
+                    </div>
+                </div>
+                <div ng-if="content.cookies"  class="col-md-2">
+                    <div class="panel panel-{{ content.cookies==0 ? 'default' : 'info' }} ">
+                        <div class="panel-heading text-center">
+                            Cookies
+                        </div>
+                        <div class="panel-body text-center">
+                            <h3>{{content.cookies}}</h3>
+                        </div>
+                    </div>
+                </div>
+                <div ng-if="content.hostpairs"  class="col-md-2">
+                    <div class="panel panel-{{ content.hostpairs==0 ? 'default' : 'info' }} ">
+                        <div class="panel-heading text-center">
+                            Host Pairs
+                        </div>
+                        <div class="panel-body text-center">
+                            <h3>{{content.hostpairs}}</h3>
+                        </div>
+                    </div>
+                </div>
+                <div ng-if="content.services" class="col-md-2">
+                    <div class="panel panel-{{ content.services==0 ? 'default' : 'info' }} ">
+                        <div class="panel-heading text-center">
+                            Services
+                        </div>
+                        <div class="panel-body text-center">
+                            <h3>{{content.services}}</h3>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+    </div>
+
+</div>
+
+<div class="panel panel-danger" ng-if="!success">
+    <div class="panel-heading">
+        <strong>{{(artifact.data || artifact.attachment.name) | fang}}</strong>
+    </div>
+    <div class="panel-body">
+        {{content.errorMessage}}
+    </div>
+</div>

--- a/thehive-templates/RiskIQ_Trackers_1_0/long.html
+++ b/thehive-templates/RiskIQ_Trackers_1_0/long.html
@@ -1,0 +1,81 @@
+<div class="report-PT" ng-if="success">
+    <style>
+        .report-PT dl {
+            margin-bottom: 2px;
+        }
+    </style>
+
+
+    <div class="panel panel-info">
+        <div class="panel-body">
+            <div ng-if="content.records.length === 0">
+                No trackers available for this IOC.
+            </div>
+            <div ng-if="content.records.length !== 0" class="panel panel-default">
+                <div class="panel-heading">
+                    <strong>RiskIQ Trackers</strong>
+                </div>
+                <div class="panel-body">
+                    <div class="row">
+                        <div class="col-xs-6">
+                            <div class="panel panel-info">
+                                <div class="panel-heading"><b>Distinct Trackers</b></div>
+                                <div class="panel-body">
+                                    <table class="tabel table-condensed">
+                                        <tr ng-repeat="d in content.distinct_categories">
+                                            <td>{{d}}</td>
+                                        </tr>
+                                    </table>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-xs-6">
+                            <div class="panel panel-info">
+                                <div class="panel-heading"><b>Distinct Values</b></div>
+                                <div class="panel-body">
+                                    <table class="tabel table-condensed">
+                                        <tr ng-repeat="d in content.distinct_values">
+                                            <td>{{d}}</td>
+                                        </tr>
+                                    </table>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="panel panel-info">
+                        <div class="panel-heading"><b>Tracker History</b></div>
+                        <div class="panel-body">
+                            <table class="table table-hover table-condensed">
+                                <thead>
+                                    <tr>
+                                        <th>Tracker</th>
+                                        <th>Value</th>
+                                        <th>First Seen</th>
+                                        <th>Last Seen</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr ng-repeat="t in content.records">
+                                        <td>{{t.trackertype}}</td>
+                                        <td>{{t.value}}</td>
+                                        <td>{{t.firstseen}}</td>
+                                        <td>{{t.lastseen}}</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="panel panel-danger" ng-if="!success">
+    <div class="panel-heading">
+        <strong>{{(artifact.data || artifact.attachment.name) | fang}}</strong>
+    </div>
+    <div class="panel-body">
+        {{content.errorMessage}}
+    </div>
+</div>

--- a/thehive-templates/RiskIQ_Whois_1_0/long.html
+++ b/thehive-templates/RiskIQ_Whois_1_0/long.html
@@ -1,0 +1,171 @@
+<div class="report-PT" ng-if="success">
+    <style>
+        .report-PT dl {
+            margin-bottom: 2px;
+        }
+        .fieldlabel {
+            font-size: 10pt;
+            color: #777;
+        }
+        .fieldvalue {
+            font-weight: 600;
+            margin-bottom: 5px;
+        }
+    </style>
+
+    <div class="panel panel-info">
+        <div class="panel-body">
+            <div ng-if="content.records.length === 0">
+                No Whois data available for this IOC.
+            </div>
+            <div ng-if="content.records.length !== 0" class="panel panel-default">
+                <div class="panel-heading">
+                    <strong>RiskIQ Whois Record</strong>
+                </div>
+                <div class="panel-body">
+                    <div class="panel">
+                        <div class="panel-body">
+                            <div class="row">
+                                <div class="col-xs-6">
+                                    <div class="panel panel-info">
+                                        <div class="panel-heading"><strong>Primary Contact</strong></div>
+                                        <div class="panel-body">
+                                            <div class='fieldlabel'>Name</div>
+                                            <div class='fieldvalue'>{{content.name}}&nbsp;</div>
+                                            <div class='fieldlabel'>Organization</div>
+                                            <div class='fieldvalue'>{{content.organization}}&nbsp;</div>
+                                            <div class='fieldlabel'>Telephone</div>
+                                            <div class='fieldvalue'>{{content.telephone}}&nbsp;</div>
+                                            <div class='fieldlabel'>Email</div>
+                                            <div class='fieldvalue'>{{content.email}}&nbsp;</div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-xs-6">
+                                    <div class="panel panel-info">
+                                        <div class="panel-heading"><strong>Domain Registration</strong></div>
+                                        <div class="panel-body">
+                                            <div class='fieldlabel'>Registered</div>
+                                            <div class='fieldvalue'>
+                                                {{content.registered}}
+                                                <span style="font-size: 14px;" class="label label-danger" ng-if="content.age < 60">{{content.age}}day<span ng-if="content.age!==1">s</span></span>
+                                                <span style="font-size: 14px;" class="label label-warning" ng-if="content.age >= 60 && content.age < 180">{{content.age}} days</span>
+                                                <span style="font-size: 14px;" class="label label-default" ng-if="content.age >= 180">{{content.age}} days</span>
+                                            </div>
+                                            <div class='fieldlabel'>Expires</div>
+                                            <div class='fieldvalue'>{{content.expiresAt}}&nbsp;</div>
+                                            <div class='fieldlabel'>Registrar</div>
+                                            <div class='fieldvalue'>{{content.registrar}}&nbsp;</div>
+                                            <div class='fieldlabel'>Registry Updated</div>
+                                            <div class='fieldvalue'>{{content.registryUpdatedAt}}&nbsp;</div>
+                                            <div class='fieldlabel'>Name Servers</div>
+                                            <div class='fieldvalue' ng-repeat="ns in content.nameServers">{{ns}}</div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-xs-6">
+                                    <div class="panel panel-info">
+                                        <div class="panel-heading"><strong>Admin Contact</strong></div>
+                                        <div class="panel-body">
+                                            <div class='fieldlabel'>Name</div>
+                                            <div class='fieldvalue'>{{content.admin.name}}&nbsp;</div>
+                                            <div class='fieldlabel'>Organization</div>
+                                            <div class='fieldvalue'>{{content.admin.organization}}&nbsp;</div>
+                                            <div class='fieldlabel'>Telephone</div>
+                                            <div class='fieldvalue'>{{content.admin.telephone}}&nbsp;</div>
+                                            <div class='fieldlabel'>Email</div>
+                                            <div class='fieldvalue'>{{content.admin.email}}&nbsp;</div>
+                                            <div class='fieldlabel'>State/Province/Region</div>
+                                            <div class='fieldvalue'>{{content.admin.state}}&nbsp;</div>
+                                            <div class='fieldlabel'>Country</div>
+                                            <div class='fieldvalue'>{{content.admin.country}}&nbsp;</div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-xs-6">
+                                    <div class="panel panel-info">
+                                        <div class="panel-heading"><strong>Registrant Contact</strong></div>
+                                        <div class="panel-body">
+                                            <div class='fieldlabel'>Name</div>
+                                            <div class='fieldvalue'>{{content.registrant.name}}&nbsp;</div>
+                                            <div class='fieldlabel'>Organization</div>
+                                            <div class='fieldvalue'>{{content.registrant.organization}}&nbsp;</div>
+                                            <div class='fieldlabel'>Telephone</div>
+                                            <div class='fieldvalue'>{{content.registrant.telephone}}&nbsp;</div>
+                                            <div class='fieldlabel'>Email</div>
+                                            <div class='fieldvalue'>{{content.registrant.email}}&nbsp;</div>
+                                            <div class='fieldlabel'>State/Province/Region</div>
+                                            <div class='fieldvalue'>{{content.registrant.state}}&nbsp;</div>
+                                            <div class='fieldlabel'>Country</div>
+                                            <div class='fieldvalue'>{{content.registrant.country}}&nbsp;</div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            <div class="row">
+                                <div class="col-xs-6">
+                                    <div class="panel panel-info">
+                                        <div class="panel-heading"><strong>Tech Contact</strong></div>
+                                        <div class="panel-body">
+                                            <div class='fieldlabel'>Name</div>
+                                            <div class='fieldvalue'>{{content.tech.name}}&nbsp;</div>
+                                            <div class='fieldlabel'>Organization</div>
+                                            <div class='fieldvalue'>{{content.tech.organization}}&nbsp;</div>
+                                            <div class='fieldlabel'>Telephone</div>
+                                            <div class='fieldvalue'>{{content.tech.telephone}}&nbsp;</div>
+                                            <div class='fieldlabel'>Email</div>
+                                            <div class='fieldvalue'>{{content.tech.email}}&nbsp;</div>
+                                            <div class='fieldlabel'>State/Province/Region</div>
+                                            <div class='fieldvalue'>{{content.tech.state}}&nbsp;</div>
+                                            <div class='fieldlabel'>Country</div>
+                                            <div class='fieldvalue'>{{content.tech.country}}&nbsp;</div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-xs-6">
+                                    <div class="panel panel-info">
+                                        <div class="panel-heading"><strong>Billing Contact</strong></div>
+                                        <div class="panel-body">
+                                            <div class='fieldlabel'>Name</div>
+                                            <div class='fieldvalue'>{{content.billing.name}}&nbsp;</div>
+                                            <div class='fieldlabel'>Organization</div>
+                                            <div class='fieldvalue'>{{content.billing.organization}}&nbsp;</div>
+                                            <div class='fieldlabel'>Telephone</div>
+                                            <div class='fieldvalue'>{{content.billing.telephone}}&nbsp;</div>
+                                            <div class='fieldlabel'>Email</div>
+                                            <div class='fieldvalue'>{{content.billing.email}}&nbsp;</div>
+                                            <div class='fieldlabel'>State/Province/Region</div>
+                                            <div class='fieldvalue'>{{content.billing.state}}&nbsp;</div>
+                                            <div class='fieldlabel'>Country</div>
+                                            <div class='fieldvalue'>{{content.billing.country}}&nbsp;</div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="panel panel-info">
+                                <div class="panel-heading">
+                                    <strong>Raw Whois Record</strong>
+                                </div>
+                                <div class="panel-body">
+                                    <pre>{{content.rawText}}</pre>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="panel panel-danger" ng-if="!success">
+    <div class="panel-heading">
+        <strong>{{(artifact.data || artifact.attachment.name) | fang}}</strong>
+    </div>
+    <div class="panel-body">
+        {{content.errorMessage}}
+    </div>
+</div>


### PR DESCRIPTION
### Introduces new analyzers and templates for RiskIQ Illuminate.

RiskIQ Illuminate is the next-generation product from RiskIQ, the company behind PassiveTotal. Many of these new analyzers overlap with datasets already in use in the existing PassiveTotal analyzers, but we wanted to take a fresh approach to their presentation and code, and also leverage our newly-updated `passivetotal` Python library. This helps ensures no breaking changes for existing users of the PassiveTotal analyzers.

We are also offering a pattern for testing analyzers and automatically generating JSON service files (see _services.py for details). This helped us quickly test our analyzers at the command line and ensured consistency in the JSON service files. It may be something to consider adding to your `cortexutils` Python library.

Looking forward to hearing your feedback.

-- Mark