### PR TITLE
Install cortexutils for DomainToolsIris_AddRiskyDNSTag

### DIFF
--- a/responders/DomainToolsIris_AddRiskyDNSTag/requirements.txt
+++ b/responders/DomainToolsIris_AddRiskyDNSTag/requirements.txt
@@ -1,0 +1,1 @@
+cortexutils


### PR DESCRIPTION
The `requirements.txt` file seems to be empty, resulting an error akin to the following bug: TheHive-Project/Cortex#334.
Hence, install `cortexutils` for `DomainToolsIris_AddRiskyDNSTag`.