### PR TITLE
Fix VirustotalDownloader for TH4py 1.8.1

### DIFF
--- a/responders/VirustotalDownloader/VirustotalDownloader.py
+++ b/responders/VirustotalDownloader/VirustotalDownloader.py
@@ -61,7 +61,7 @@ class VirustotalDownloader(Responder):
 
                     file_observable = CaseObservable(
                         dataType="file",
-                        data=[filename],
+                        data=filename,
                         tlp=self.get_param("data.tlp"),
                         ioc=True,
                         tags=[
@@ -75,7 +75,7 @@ class VirustotalDownloader(Responder):
                 else:
                     file_observable = CaseObservable(
                         dataType="file",
-                        data=[f.name],
+                        data=f.name,
                         tlp=self.get_param("data.tlp"),
                         ioc=True,
                         tags=[


### PR DESCRIPTION
I don't know if it works with previous th4py versions but this changes fixes on models.py - class CaseObservable:

file_object = open(filename, 'rb') 
TypeError: expected str, bytes or os.PathLike object, not list