### PR TITLE
Update virustotal.py

### DIFF
--- a/analyzers/VirusTotal/virustotal.py
+++ b/analyzers/VirusTotal/virustotal.py
@@ -275,7 +275,7 @@ class VirusTotalAnalyzer(Analyzer):
 
             # if aged and enabled rescan
             if self.data_type == "hash" and self.rescan_hash_older_than_days:
-                if (
+                if "scan_date" in results and (
                     datetime.strptime(results["scan_date"], "%Y-%m-%d %H:%M:%S")
                     - datetime.now()
                 ).days > self.rescan_hash_older_than_days:


### PR DESCRIPTION
Hello,
I tried to analyze an unknown hash on VirusTotal with the ```rescan_hash_older_than_days``` option enabled and got a key error, since "scan_date" was not part of the response.
It seems like checking if the field exists fixes the error.

<img width="490" alt="Unbenannt" src="https://user-images.githubusercontent.com/84137008/138674792-d4ac934c-10b9-4081-877a-3ed7c3c43d4e.PNG">
I hope this helps.