### PR TITLE
cortexutils not installed in RT4 Responder Docker Image

### DIFF
--- a/responders/RT4/requirements.txt
+++ b/responders/RT4/requirements.txt
@@ -2,3 +2,4 @@ defang
 jinja2
 rt
 requests
+cortexutils


### PR DESCRIPTION
Running the RT4 responder in Docker throws a ModuleNotFound error.: 

Traceback (most recent call last):
  File "/worker/RT4/rt4.py", line 4, in <module>
    from cortexutils.responder import Responder
ModuleNotFoundError: No module named 'cortexutils'

Is it possible to correct this Docker image present in the Docker Hub repository ?