### PR TITLE
Add authentication option for Maltiverse

### DIFF
--- a/analyzers/Maltiverse/Maltiverse_Report.json
+++ b/analyzers/Maltiverse/Maltiverse_Report.json
@@ -19,6 +19,14 @@
       "multi": false,
       "required": false,
       "defaultValue": 60
+    },
+    {
+      "name": "api_key",
+      "description": "Auth token to use when requesting data to Maltiverse",
+      "type": "string",
+      "multi": false,
+      "required": false,
+      "defaultValue": ""
     }
   ],
   "registration_required": false,

--- a/analyzers/Maltiverse/maltiverse-client.py
+++ b/analyzers/Maltiverse/maltiverse-client.py
@@ -13,11 +13,10 @@ class MaltiverseAnalyzer(Analyzer):
     def __init__(self):
         Analyzer.__init__(self)
         self.service = self.get_param('config.service', None, 'Service parameter is missing')
-        # self.username = self.get_param('config.username', None, 'Missing Maltiverse API Username')
-        # self.password = self.get_param('config.password', None, 'Missing Maltiverse API Password')
         self.polling_interval = self.get_param('config.polling_interval', 60)
         self.proxies = self.get_param('config.proxy', None)
-        self.m = Maltiverse()
+        self.api_key = self.get_param('config.api_key', None)
+        self.m = Maltiverse(auth_token=self.api_key)
 
     def maltiverse_query_ip(self, data):
         try:
@@ -108,7 +107,7 @@ class MaltiverseAnalyzer(Analyzer):
                 level = "safe"
             value = "{}".format(raw["classification"])
 
-        
+
         taxonomies.append(self.build_taxonomy(level, namespace, predicate, value))
 
         return {"taxonomies": taxonomies}


### PR DESCRIPTION
This PR adds an authentication parameter within the Maltiverse analyzer so you can use your subscription from the platform.

