### PR TITLE
feat: Improve templates for SEKOIA analyzers

### DIFF
--- a/thehive-templates/SEKOIAIntelligenceCenter_Context_1_0/long.html
+++ b/thehive-templates/SEKOIAIntelligenceCenter_Context_1_0/long.html
@@ -13,8 +13,12 @@
                 <div class="panel-body">
                     <div>
                         <dl class="dl-horizontal">
+                            <dt>ID</dt>
+                            <dd class="wrap">{{item.id}}</dd>
+                        </dl>
+                        <dl class="dl-horizontal">
                             <dt>Type</dt>
-                            <dd class="wrap">{{item.type}}</dd>
+                            <dd class="wrap">{{item.type}}<span ng-if="item.x_ic_is_source"> (source)</span><span ng-if="item.x_ic_is_sector"> (sector)</span></dd>
                         </dl>
                         <dl class="dl-horizontal" ng-if="item.aliases">
                             <dt>Aliases</dt>
@@ -23,6 +27,13 @@
                                 <div ng-if="item.aliases.length > 0">
                                     <span class="label label-info" style="margin: 2px;" ng-repeat="alias in item.aliases">{{alias}}</span> 
                                 </div>
+                            </dd>
+                        </dl>
+                        <dl class="dl-horizontal">
+                            <dt>Tags</dt>
+                            <dd>
+                                <span class="label label-danger" style="margin: 2px;" ng-if="item.revoked" >Revoked</span>
+                                <span class="label label-success" style="margin: 2px;" ng-if="!item.revoked" >Not Revoked</span>
                             </dd>
                         </dl>
                         <dl class="dl-horizontal">

--- a/thehive-templates/SEKOIAIntelligenceCenter_Indicators_1_0/long.html
+++ b/thehive-templates/SEKOIAIntelligenceCenter_Indicators_1_0/long.html
@@ -10,6 +10,17 @@
         <div class="panel-body">
             <div>
                 <dl class="dl-horizontal">
+                    <dt>ID</dt>
+                    <dd class="wrap">{{item.id}}</dd>
+                </dl>
+                <dl class="dl-horizontal">
+                    <dt>Tags</dt>
+                    <dd>
+                        <span class="label label-danger" style="margin: 2px;" ng-if="item.revoked" >Revoked</span>
+                        <span class="label label-success" style="margin: 2px;" ng-if="!item.revoked" >Not Revoked</span>
+                    </dd>
+                </dl>
+                <dl class="dl-horizontal">
                     <dt>Description</dt>
                     <dd class="wrap">{{indicator.description || 'No description' }}</dd>
                 </dl>

--- a/thehive-templates/SEKOIAIntelligenceCenter_Observables_1_0/long.html
+++ b/thehive-templates/SEKOIAIntelligenceCenter_Observables_1_0/long.html
@@ -9,6 +9,10 @@
         </div>
         <div class="panel-body">
             <div>
+                <dl class="dl-horizontal">
+                    <dt>ID</dt>
+                    <dd class="wrap">{{item.id}}</dd>
+                </dl>
                 <dl class="dl-horizontal" ng-if="observable.value">
                     <dt>Value</dt>
                     <dd class="wrap">{{observable.value | fang}}</dd>


### PR DESCRIPTION
Improve the report templates with the following improvements:

* Display the object's ID
* Display the revocation status
* Indicate when the object is a source or a sector

I didn't know if you should have created a PR against master or develop, if needed I can change it :)