### PR TITLE
Update TorBlutMagie to point to alternative domain

### DIFF
--- a/analyzers/TorBlutmagie/TorBlutmagie.json
+++ b/analyzers/TorBlutmagie/TorBlutmagie.json
@@ -4,7 +4,7 @@
   "license": "AGPL-V3",
   "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
   "version": "1.0",
-  "description": "Query http://torstatus.blutmagie.de/query_export.php/Tor_query_EXPORT.csv for TOR exit nodes IP addresses or names.",
+  "description": "Query https://torstatus.rueckgr.at/query_export.php/Tor_query_EXPORT.csv (formerly TorBlutmagie) for TOR exit nodes IP addresses or names.",
   "dataTypeList": ["ip", "domain", "fqdn"],
   "command": "TorBlutmagie/tor_blutmagie_analyzer.py",
   "baseConfig": "TorBlutmagie",
@@ -24,5 +24,9 @@
       "multi": false,
       "required": false
     }
-  ]
+  ],
+  "registration_required": false,
+  "subscription_required": false,
+  "free_subscription": true,
+  "service_homepage": "https://torstatus.rueckgr.at"
 }

--- a/analyzers/TorBlutmagie/tor_blutmagie.py
+++ b/analyzers/TorBlutmagie/tor_blutmagie.py
@@ -23,7 +23,7 @@ class TorBlutmagieClient:
         self.cache_duration = cache_duration
         if self.cache_duration > 0:
             self.cache = Cache(cache_root)
-        self.url = 'http://torstatus.blutmagie.de/query_export.php/Tor_query_EXPORT.csv'
+        self.url = 'https://torstatus.rueckgr.at/query_export.php/Tor_query_EXPORT.csv'
 
     __cache_key = __name__ + ':raw_data'
 


### PR DESCRIPTION
TorBlutMagie has been taken down since 2018 this will fix it by using an alternative domain that exports the same information. I can rework the Analyser if required to be refereed to as the new domain however I left it as is for the moment so people who may have used it understand it is the same tool and should work the same way besides referencing a different domain. 