### PR TITLE
Update of NERD analyzer

### DIFF
--- a/analyzers/NERD/README.md
+++ b/analyzers/NERD/README.md
@@ -1,10 +1,16 @@
-### Nerd 
-Project [Nerd](https://nerd.cesnet.cz/) aims to build an extensive reputation database of known sources of cyber threats. That is, a list of known malicious IP addresses or other network entities (e.g. ASNs or domain names) together with all security-relevant information about each of them.
+### NERD 
 
-The analyzer comes in a single flavour that will return additional information categorization for provided ip.
+
+[NERD](https://nerd.cesnet.cz/) is a service provided by CESNET which collects information about malicious IP addresses
+from CESNET's own detection systems as well as several public sources.
+It keeps a profile of each known malicious IP address, containing all security-relevant information about the
+address, and it summarizes it into a *reputation score* - a number from 0.0 (good) to 1.0 (bad) representing the amount
+and confidence of recently received reports about that address.
+
+The analyzer comes in a single flavour that will return the reputation score and various tags for provided IP.
 
 #### Requirements
-You need a valid Nerd API integration subscription to use the analyzer.
+You need a valid NERD API integration subscription to use the analyzer.
 
 - Provide your API key as values for the `key` parameter.
-- Default url of NERD instance is provided for `url` parameter but you could override it.
+- Default url of NERD instance is provided for `url` parameter, but you could override it.

--- a/analyzers/NERD/nerd.json
+++ b/analyzers/NERD/nerd.json
@@ -1,6 +1,6 @@
 {
   "name": "NERD",
-  "version": "1.0",
+  "version": "1.1",
   "author": "Vaclav Bartos, CESNET",
   "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
   "license": "AGPL-V3",


### PR DESCRIPTION
- added support for "whitelist" tag (i.e. IPs whitelisted in NERD shows as such in Cortex)
- better error handling, distinguish 404 because of unknown IP address from other reasons (e.g. wrong base_url)
- README updated
- version set to 1.1

Fully tested on my Cortex instance.