### PR TITLE
bump abuse_finder

### DIFF
--- a/analyzers/Abuse_Finder/requirements.txt
+++ b/analyzers/Abuse_Finder/requirements.txt
@@ -1,3 +1,3 @@
 cortexutils
-abuse_finder
+abuse_finder>=0.3
 future


### PR DESCRIPTION
Abuse finder was recently made compatible with current python versions. Reflecting the change here

This should fix https://github.com/TheHive-Project/Cortex/issues/352 and https://github.com/TheHive-Project/Cortex-Analyzers/issues/940