### PR TITLE
Cloudflare Account IP Access List Responder

### DIFF
--- a/responders/Cloudflare_IP_Blocker/CloudflareIPBlocker.json
+++ b/responders/Cloudflare_IP_Blocker/CloudflareIPBlocker.json
@@ -30,6 +30,9 @@
             "multi": false,
             "required": true
         }
-    ]
-
+    ],
+    "registration_required": true,
+    "subscription_required": true,
+    "free_subscription": false,
+    "service_homepage": "https://www.cloudflare.com"
 }

--- a/responders/Cloudflare_IP_Blocker/CloudflareIPBlocker.json
+++ b/responders/Cloudflare_IP_Blocker/CloudflareIPBlocker.json
@@ -1,0 +1,35 @@
+{
+    "name": "Cloudflare_IP_Blocker",
+    "version": "1.0",
+    "author": "Nick Babkin @nickbabkin",
+    "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
+    "license": "AGPL-V3",
+    "description": "Block IP Address on Account level in Cloudflare",
+    "dataTypeList": ["thehive:case_artifact"],
+    "command": "Cloudflare_IP_Blocker/CloudflareIPBlocker.py",
+    "baseConfig": "CloudflareIPBlocker",
+    "configurationItems": [
+        {
+            "name": "cloudflare_api_key",
+            "description": "Cloudflare API Key",
+            "type": "string",
+            "multi": false,
+            "required": true
+        },
+        {
+            "name": "cloudflare_account_ids",
+            "description": "Cloudflare Account IDs to block IP address in",
+            "type": "string",
+            "multi": true,
+            "required": true
+          },
+        {
+            "name": "cloudflare_action",
+            "description": "Cloudflare Action: block, challenge, whitelist, js_challenge or managed_challenge",
+            "type": "string",
+            "multi": false,
+            "required": true
+        }
+    ]
+
+}

--- a/responders/Cloudflare_IP_Blocker/CloudflareIPBlocker.py
+++ b/responders/Cloudflare_IP_Blocker/CloudflareIPBlocker.py
@@ -7,7 +7,7 @@ import datetime
 import os
 from cortexutils.responder import Responder
 
-# Initialize Azure Class
+# Initialize Cloudflare Responder Class
 class CloudflareIPBlocker(Responder):
     
     def __init__(self):
@@ -49,7 +49,7 @@ class CloudflareIPBlocker(Responder):
                     self.error('Request failed with the following status: {}'.format(response.status_code))
                 
                 else:
-                    #record time of successful auth token revokation
+                    #record time
                     self.time = datetime.datetime.utcnow()
         
         except Exception as ex:

--- a/responders/Cloudflare_IP_Blocker/CloudflareIPBlocker.py
+++ b/responders/Cloudflare_IP_Blocker/CloudflareIPBlocker.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+# Author: Nick Babkin @nickbabkin
+import requests
+import traceback
+import datetime
+import os
+from cortexutils.responder import Responder
+
+# Initialize Azure Class
+class CloudflareIPBlocker(Responder):
+    
+    def __init__(self):
+        Responder.__init__(self)
+        self.cloudflare_api_key = self.get_param('config.cloudflare_api_key', None, 'Cloudflare API Key')
+        self.cloudflare_account_ids = self.get_param('config.cloudflare_account_ids', [], 'Cloudflare Account ID')
+        self.cloudflare_action = self.get_param('config.cloudflare_action', [], 'Cloudflare Action')
+        self.time = ''
+        self.dataType = self.get_param('data.dataType')
+
+    def run(self):
+        try:
+            if self.dataType== "ip":
+                self.ip_address = self.get_param('data.data', None, 'No IP Address supplied')
+            else:
+                self.error("No IP Address supplied")
+            
+            # Build the request payload to block the IP address
+            payload = {
+                "mode": self.cloudflare_action,
+                "configuration": {
+                    "target": "ip",
+                    "value": self.ip_address,
+                },
+                "notes": "Blocked by Hive responder. Case number {}".format(self.get_param('data.case.caseId', None, 'No CaseID Fetched'))
+            }      
+            
+            # Make the API request to Cloudflare
+            for account_id in self.cloudflare_account_ids:
+                url = "https://api.cloudflare.com/client/v4/accounts/{}/firewall/access_rules/rules".format(account_id)
+                headers = {
+                    "Authorization": "Bearer {}".format(self.cloudflare_api_key),
+                    "Content-Type": "application/json"
+                }
+                response = requests.post(url, headers=headers, json=payload)
+
+                # Checking for errors
+                if response.status_code != 200:
+                    self.error('Request failed with the following status: {}'.format(response.status_code))
+                
+                else:
+                    #record time of successful auth token revokation
+                    self.time = datetime.datetime.utcnow()
+        
+        except Exception as ex:
+            self.error(traceback.format_exc())
+        # Build report to return to Cortex
+        full_report = {"message": "IP Address {} successfully blocked at {}".format(self.ip_address, self.time)}
+        self.report(full_report)
+        
+    def operations(self, raw):
+        return [self.build_operation('AddTagToArtifact', tag='Cloudflare:Blocked')]
+
+
+if __name__ == '__main__':
+    CloudflareIPBlocker().run()

--- a/responders/Cloudflare_IP_Blocker/requirements.txt
+++ b/responders/Cloudflare_IP_Blocker/requirements.txt
@@ -1,0 +1,3 @@
+cortexutils
+requests
+datetime


### PR DESCRIPTION
Hi!
Contributing with responder that allows to add Cloudflare Account IP Access list entry and block/challenge/whitelist any IP from case observables.

Supports multiple accounts as input.


API Documentation: https://developers.cloudflare.com/api/operations/ip-access-rules-for-an-account-create-an-ip-access-rule