### PR TITLE
Fix analyzer and long report templates

### DIFF
--- a/analyzers/SEKOIAIntelligenceCenter/sekoia_intelligence_center_analyzer.py
+++ b/analyzers/SEKOIAIntelligenceCenter/sekoia_intelligence_center_analyzer.py
@@ -53,6 +53,8 @@ class IntelligenceCenterAnalyzer(Analyzer):
             has_threats = any(res.get("x_ic_indicated_threats") for res in raw["results"])
             if has_threats:
                 taxonomies.append(self.build_taxonomy("malicious", "SEKOIA", self.service, value))
+            else;
+                taxonomies.append(self.build_taxonomy("safe", "SEKOIA", self.service, value))
         else:
             taxonomies.append(self.build_taxonomy("malicious", "SEKOIA", self.service, value))
 

--- a/thehive-templates/SEKOIAIntelligenceCenter_Context_1_0/long.html
+++ b/thehive-templates/SEKOIAIntelligenceCenter_Context_1_0/long.html
@@ -3,7 +3,7 @@
         No results found
     </div>
     <h2 ng-if="content.results.length > 0">{{content.results.length}} Context(s)</h2>
-    <div ng-repeat="bundle in content.results track by 'id'">
+    <div ng-repeat="bundle in content.results track by bundle.id">
         <h4>{{bundle.id}}</h4>
         <div ng-if="bundle.objects.length > 0" ng-repeat="item in bundle.objects">
             <div class="panel panel-info" ng-if="item.type !== 'relationship' && item.type !== 'marking-definition'">

--- a/thehive-templates/SEKOIAIntelligenceCenter_Indicators_1_0/long.html
+++ b/thehive-templates/SEKOIAIntelligenceCenter_Indicators_1_0/long.html
@@ -3,7 +3,7 @@
         No results found
     </div>
     <h2 ng-if="content.results.length > 0">{{content.results.length}} Indicator(s)</h2>
-    <div class="panel panel-info" ng-if="content.results.length > 0" ng-repeat="indicator in content.results track by 'id'">
+    <div class="panel panel-info" ng-if="content.results.length > 0" ng-repeat="indicator in content.results track by indicator.id">
         <div class="panel-heading">
             <strong>{{indicator.name | fang}}</strong>
         </div>

--- a/thehive-templates/SEKOIAIntelligenceCenter_Observables_1_0/long.html
+++ b/thehive-templates/SEKOIAIntelligenceCenter_Observables_1_0/long.html
@@ -3,7 +3,7 @@
         No results found
     </div>
     <h2 ng-if="content.results.length > 0">{{content.results.length}} Observable(s)</h2>
-    <div class="panel panel-info" ng-if="content.results.length > 0" ng-repeat="observable in content.results track by 'id'">
+    <div class="panel panel-info" ng-if="content.results.length > 0" ng-repeat="observable in content.results track by observable.id">
         <div class="panel-heading">
             <strong>{{observable.x_inthreat_short_display | fang}}</strong>
         </div>


### PR DESCRIPTION
Fixes added to the Sekoia.io analyzers:
- Add a taxonomy observables known in Sekoia.io without indicated threats
- Fix long report templates - reports were not displayed when the analyzer returns more than 1 result