### PR TITLE
Fix missing requirements.txt in CrowdSec Analyzer

### DIFF
--- a/analyzers/Crowdsec/requirements.txt
+++ b/analyzers/Crowdsec/requirements.txt
@@ -1,1 +1,2 @@
 cortexutils
+requests


### PR DESCRIPTION
Add "requests" in `requirements.txt` file in CrowdSec Analyzer.

Fix #1173 