### PR TITLE
Fixes and added features to Defender for endpoints responder

### DIFF
--- a/responders/MSDefenderEndpoints/Dockerfile
+++ b/responders/MSDefenderEndpoints/Dockerfile
@@ -17,5 +17,5 @@
 FROM python:3
 WORKDIR /worker
 COPY . MSDefenderEndpoints
-RUN test ! -e MSDefenderEndpoints/requirements.txt || pip install --no-cache-dir -rMSDefenderEndpoints/requirements.txt
+RUN test ! -e MSDefenderEndpoints/requirements.txt || pip install --no-cache-dir -r MSDefenderEndpoints/requirements.txt
 ENTRYPOINT MSDefenderEndpoints/MSDefenderEndpoints.py

--- a/responders/MSDefenderEndpoints/MSDefenderEndpoints.py
+++ b/responders/MSDefenderEndpoints/MSDefenderEndpoints.py
@@ -327,6 +327,10 @@ class MSDefenderEndpoints(Responder):
             return [self.build_operation("AddTagToArtifact", tag="MsDefender:fullVirusScan")]
         elif self.service == "unisolateMachine":
             return [self.build_operation("AddTagToArtifact", tag="MsDefender:unIsolated")]
+        elif self.service == "restrictAppExecution":
+            return [self.build_operation("AddTagToArtifact", tag="MsDefender:restrictedAppExec")]
+        elif self.service == "unrestrictAppExecution":
+            return [self.build_operation("AddTagToArtifact", tag="MsDefender:unrestrictedAppExec")]
 
 if __name__ == '__main__':
     

--- a/responders/MSDefenderEndpoints/MSDefenderEndpoints.py
+++ b/responders/MSDefenderEndpoints/MSDefenderEndpoints.py
@@ -155,6 +155,74 @@ class MSDefenderEndpoints(Responder):
             except requests.exceptions.RequestException as e:
                 self.error({'message': e})
 
+
+        def restrictAppExecution(machineId):
+            '''
+            example
+            POST https://api.securitycenter.windows.com/api/machines/{id}/restrictCodeExecution
+            '''
+            url = 'https://api.securitycenter.windows.com/api/machines/{}/restrictCodeExecution'.format(machineId)
+            body = {
+                'Comment': 'Restrict code execution due to TheHive case {}'.format(self.caseId)
+                }
+
+            try:
+                response = self.msdefenderSession.post(url=url, json=body)
+                if response.status_code == 201:
+                    self.report({'message': "Restricted app execution on machine: " + self.observable })
+                elif response.status_code == 400 and "ActiveRequestAlreadyExists" in response.content.decode("utf-8"):
+                    self.report({'message': "Error restricting app execution on machine: ActiveRequestAlreadyExists"})
+                else:
+                    self.error({'message': "Can't restrict app execution"})
+            except requests.exceptions.RequestException as e:
+                self.error({'message': e})
+
+        
+        def unrestrictAppExecution(machineId):
+            '''
+            example
+            POST https://api.securitycenter.windows.com/api/machines/{id}/unrestrictCodeExecution
+            '''
+            url = 'https://api.securitycenter.windows.com/api/machines/{}/unrestrictCodeExecution'.format(machineId)
+            body = {
+                'Comment': '"Remove code execution restriction since machine was cleaned and validated due to TheHive case {}'.format(self.caseId)
+                }
+
+            try:
+                response = self.msdefenderSession.post(url=url, json=body)
+                if response.status_code == 201:
+                    self.report({'message': "Removed app execution restriction on machine: " + self.observable })
+                elif response.status_code == 400 and "ActiveRequestAlreadyExists" in response.content.decode("utf-8"):
+                    self.report({'message': "Error removing app execution restriction on machine: ActiveRequestAlreadyExists"})
+                else:
+                    self.error({'message': "Can't unrestrict app execution"})
+            except requests.exceptions.RequestException as e:
+                self.error({'message': e})
+
+        
+        def startAutoInvestigation(machineId):
+            '''
+            example
+            POST https://api.securitycenter.windows.com/api/machines/{id}/startInvestigation
+            '''
+            url = 'https://api.securitycenter.windows.com/api/machines/{}/startInvestigation'.format(machineId)
+
+            body = {
+                'Comment': 'Start investigation due to TheHive case {}'.format(self.caseId)
+                }
+
+            try:
+                response = self.msdefenderSession.post(url=url, json=body)
+                if response.status_code == 201:
+                    self.report({'message': "Started Auto Investigation on : " + self.observable })
+                elif response.status_code == 400 and "ActiveRequestAlreadyExists" in response.content.decode("utf-8"):
+                    self.report({'message': "Error lauching auto investigation on machine: ActiveRequestAlreadyExists"})
+                else:
+                    self.error({'message': "Error auto investigation on machine"})
+            except requests.exceptions.RequestException as e:
+                self.error({'message': e})
+
+
         def pushCustomIocAlert(ipAddress):
             action="Alert"
             url = 'https://api.securitycenter.windows.com/api/indicators'
@@ -195,13 +263,19 @@ class MSDefenderEndpoints(Responder):
             except requests.exceptions.RequestException as e:
                 self.error({'message': e})
 
-        # print("blop")
+
         if self.service == "isolateMachine":
             isolateMachine(getMachineId(self.observable))
         elif self.service == "unisolateMachine":
             unisolateMachine(getMachineId(self.observable))
         elif self.service == "runFullVirusScan":
             runFullVirusScan(getMachineId(self.observable))
+        elif self.service == "restrictAppExecution":
+            restrictAppExecution(getMachineId(self.observable))
+        elif self.service == "unrestrictAppExecution":
+            unrestrictAppExecution(getMachineId(self.observable))
+        elif self.service == "startAutoInvestigation":
+            startAutoInvestigation(getMachineId(self.observable))
         elif self.service == "pushIOCBlock":
             pushCustomIocBlock(self.observable)
         elif self.service == "pushIOCAlert":

--- a/responders/MSDefenderEndpoints/MSDefenderEndpoints.py
+++ b/responders/MSDefenderEndpoints/MSDefenderEndpoints.py
@@ -31,7 +31,7 @@ class MSDefenderEndpoints(Responder):
 
    def run(self):
         Responder.run(self)
-        url = "{}{}/oauth2/token".format(
+        url = "{}/{}/oauth2/token".format(
             self.msdefenderOAuthUri,self.msdefenderTenantId
             )
 
@@ -77,6 +77,8 @@ class MSDefenderEndpoints(Responder):
                 if response.status_code == 200:
                     jsonResponse = response.json()
                     if len(response.content) > 100:
+                        if jsonResponse["value"][0]["aadDeviceId"] is None:
+                           return jsonResponse["value"][0]["id"]
                         return jsonResponse["value"][0]["aadDeviceId"]
                     else:
                         self.error({'message': "Can't get hostname from Microsoft API"})

--- a/responders/MSDefenderEndpoints/MSDefenderEndpoints_AutoInvestigation.json
+++ b/responders/MSDefenderEndpoints/MSDefenderEndpoints_AutoInvestigation.json
@@ -1,0 +1,61 @@
+{
+    "name": "MSDefender-AutoInvestigation",
+    "version": "1.0",
+    "author": "Keijo Korte, Louis-Maximilien Dupouy",
+    "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
+    "license": "AGPL-V3",
+    "description": "Start an automated investigation on a device",
+    "dataTypeList": ["thehive:case_artifact"],
+    "command": "MSDefenderEndpoints/MSDefenderEndpoints.py",
+    "baseConfig": "MSDefenderforEndpoints",
+    "config": {
+      "service": "startAutoInvestigation"
+    },
+    "configurationItems": [
+      {
+        "name": "tenantId",
+        "description": "Azure tenant ID",
+        "type": "string",
+        "multi": false,
+        "required": true,
+        "defaultValue": "abcdef12-ab12-abc12-ab12-abcdef123456"
+      },
+      {
+        "name": "appId",
+        "description": "Azure app ID",
+        "type": "string",
+        "multi": false,
+        "required": true,
+        "defaultValue": "abcdef12-ab12-abc12-ab12-abcdef123456"
+      },
+      {
+        "name": "appSecret",
+        "description": "Azure app secret",
+        "type": "string",
+        "multi": false,
+        "required": true,
+        "defaultValue": "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890="
+      },
+      {
+        "name": "resourceAppIdUri",
+        "description": "Security Center URI, usually doens't need to change",
+        "type": "string",
+        "multi": false,
+        "required": true,
+        "defaultValue": "https://api.securitycenter.windows.com"
+      },
+      {
+        "name": "oAuthUri",
+        "description": "Azure oAuth2 authentication endpoint",
+        "type": "string",
+        "multi": false,
+        "required": true,
+        "defaultValue": "https://login.microsoftonline.com"
+      }
+    ],
+    "registration_required": true,
+    "subscription_required": true,
+    "free_subscription": false,
+    "service_homepage": "https://securitycenter.windows.com"
+  }
+  

--- a/responders/MSDefenderEndpoints/MSDefenderEndpoints_Isolate.json
+++ b/responders/MSDefenderEndpoints/MSDefenderEndpoints_Isolate.json
@@ -50,7 +50,7 @@
       "type": "string",
       "multi": false,
       "required": true,
-      "defaultValue": "https://login.windows.net/"
+      "defaultValue": "https://login.microsoftonline.com"
     }
   ],
   "registration_required": true,

--- a/responders/MSDefenderEndpoints/MSDefenderEndpoints_PushIOCAlert.json
+++ b/responders/MSDefenderEndpoints/MSDefenderEndpoints_PushIOCAlert.json
@@ -1,7 +1,7 @@
 {
   "name": "MSDefender-PushIOC-Alert",
-  "version": "1.0",
-  "author": "Keijo Korte",
+  "version": "2.0",
+  "author": "Keijo Korte, Louis-Maximilien Dupouy",
   "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
   "license": "AGPL-V3",
   "description": "Push IOC to Defender client. Alert mode",
@@ -50,7 +50,7 @@
       "type": "string",
       "multi": false,
       "required": true,
-      "defaultValue": "https://login.windows.net/"
+      "defaultValue": "https://login.microsoftonline.com"
     }
   ],
   "registration_required": true,

--- a/responders/MSDefenderEndpoints/MSDefenderEndpoints_PushIOCBlock.json
+++ b/responders/MSDefenderEndpoints/MSDefenderEndpoints_PushIOCBlock.json
@@ -1,7 +1,7 @@
 {
   "name": "MSDefender-PushIOC-Block",
-  "version": "1.0",
-  "author": "Keijo Korte",
+  "version": "2.0",
+  "author": "Keijo Korte, Louis-Maximilien Dupouy",
   "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
   "license": "AGPL-V3",
   "description": "Push IOC to Defender client. Blocking mode",

--- a/responders/MSDefenderEndpoints/MSDefenderEndpoints_PushIOCBlock.json
+++ b/responders/MSDefenderEndpoints/MSDefenderEndpoints_PushIOCBlock.json
@@ -50,7 +50,7 @@
       "type": "string",
       "multi": false,
       "required": true,
-      "defaultValue": "https://login.windows.net/"
+      "defaultValue": "https://login.microsoftonline.com"
     }
   ],
   "registration_required": true,

--- a/responders/MSDefenderEndpoints/MSDefenderEndpoints_RestrictAppExecution.json
+++ b/responders/MSDefenderEndpoints/MSDefenderEndpoints_RestrictAppExecution.json
@@ -1,0 +1,61 @@
+{
+    "name": "MSDefender-RestrictAppExecution",
+    "version": "1.0",
+    "author": "Keijo Korte, Louis-Maximilien Dupouy",
+    "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
+    "license": "AGPL-V3",
+    "description": "Restrict execution of all applications on the device except a predefined set",
+    "dataTypeList": ["thehive:case_artifact"],
+    "command": "MSDefenderEndpoints/MSDefenderEndpoints.py",
+    "baseConfig": "MSDefenderforEndpoints",
+    "config": {
+      "service": "restrictAppExecution"
+    },
+    "configurationItems": [
+      {
+        "name": "tenantId",
+        "description": "Azure tenant ID",
+        "type": "string",
+        "multi": false,
+        "required": true,
+        "defaultValue": "abcdef12-ab12-abc12-ab12-abcdef123456"
+      },
+      {
+        "name": "appId",
+        "description": "Azure app ID",
+        "type": "string",
+        "multi": false,
+        "required": true,
+        "defaultValue": "abcdef12-ab12-abc12-ab12-abcdef123456"
+      },
+      {
+        "name": "appSecret",
+        "description": "Azure app secret",
+        "type": "string",
+        "multi": false,
+        "required": true,
+        "defaultValue": "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890="
+      },
+      {
+        "name": "resourceAppIdUri",
+        "description": "Security Center URI, usually doens't need to change",
+        "type": "string",
+        "multi": false,
+        "required": true,
+        "defaultValue": "https://api.securitycenter.windows.com"
+      },
+      {
+        "name": "oAuthUri",
+        "description": "Azure oAuth2 authentication endpoint",
+        "type": "string",
+        "multi": false,
+        "required": true,
+        "defaultValue": "https://login.microsoftonline.com"
+      }
+    ],
+    "registration_required": true,
+    "subscription_required": true,
+    "free_subscription": false,
+    "service_homepage": "https://securitycenter.windows.com"
+  }
+  

--- a/responders/MSDefenderEndpoints/MSDefenderEndpoints_UnRestrictAppExecution.json
+++ b/responders/MSDefenderEndpoints/MSDefenderEndpoints_UnRestrictAppExecution.json
@@ -1,0 +1,60 @@
+{
+  "name": "MSDefender-UnRestrictAppExecution",
+  "version": "1.0",
+  "author": "Keijo Korte, Louis-Maximilien Dupouy",
+  "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
+  "license": "AGPL-V3",
+  "description": "Enable execution of any application on the device",
+  "dataTypeList": ["thehive:case_artifact"],
+  "command": "MSDefenderEndpoints/MSDefenderEndpoints.py",
+  "baseConfig": "MSDefenderforEndpoints",
+  "config": {
+    "service": "unrestrictAppExecution"
+  },
+  "configurationItems": [
+    {
+      "name": "tenantId",
+      "description": "Azure tenant ID",
+      "type": "string",
+      "multi": false,
+      "required": true,
+      "defaultValue": "abcdef12-ab12-abc12-ab12-abcdef123456"
+    },
+    {
+      "name": "appId",
+      "description": "Azure app ID",
+      "type": "string",
+      "multi": false,
+      "required": true,
+      "defaultValue": "abcdef12-ab12-abc12-ab12-abcdef123456"
+    },
+    {
+      "name": "appSecret",
+      "description": "Azure app secret",
+      "type": "string",
+      "multi": false,
+      "required": true,
+      "defaultValue": "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890="
+    },
+    {
+      "name": "resourceAppIdUri",
+      "description": "Security Center URI, usually doens't need to change",
+      "type": "string",
+      "multi": false,
+      "required": true,
+      "defaultValue": "https://api.securitycenter.windows.com"
+    },
+    {
+      "name": "oAuthUri",
+      "description": "Azure oAuth2 authentication endpoint",
+      "type": "string",
+      "multi": false,
+      "required": true,
+      "defaultValue": "https://login.microsoftonline.com"
+    }
+  ],
+  "registration_required": true,
+  "subscription_required": true,
+  "free_subscription": false,
+  "service_homepage": "https://securitycenter.windows.com"
+}

--- a/responders/MSDefenderEndpoints/MSDefenderEndpoints_Unisolate.json
+++ b/responders/MSDefenderEndpoints/MSDefenderEndpoints_Unisolate.json
@@ -50,7 +50,7 @@
       "type": "string",
       "multi": false,
       "required": true,
-      "defaultValue": "https://login.windows.net/"
+      "defaultValue": "https://login.microsoftonline.com"
     }
   ],
   "registration_required": true,

--- a/responders/MSDefenderEndpoints/MSDefenderEndpoints_VirusScan.json
+++ b/responders/MSDefenderEndpoints/MSDefenderEndpoints_VirusScan.json
@@ -50,7 +50,7 @@
       "type": "string",
       "multi": false,
       "required": true,
-      "defaultValue": "https://login.windows.net/"
+      "defaultValue": "https://login.microsoftonline.com"
     }
   ],
   "registration_required": true,

--- a/responders/MSDefenderEndpoints/README.md
+++ b/responders/MSDefenderEndpoints/README.md
@@ -37,7 +37,7 @@ In the registration form:
 ##### API permission
 
 On your new application page, click API Permissions > Add permission > APIs my organization uses > type **WindowsDefenderATP** and click on WindowsDefenderATP
-Choose Application permissions, select **Alert.Read.All** AND **TI.ReadWrite.All** AND **Machine.ReadAll** AND **Machine.Isolate** AND **Machine.Scan** > Click on Add permissions.
+Choose Application permissions, select **Alert.Read.All** AND **TI.ReadWrite.All** AND **Machine.ReadAll** AND **Machine.Isolate** AND **Machine.Scan** AND **Machine.RestrictExecution** > Click on Add permissions.
 
 After clicking the Add Permissions button, on the next screen we need to grant consent for the permission to take effect.
 Press the "Grant admin consent for {your tenant name}" button.

--- a/responders/MSDefenderEndpoints/README.md
+++ b/responders/MSDefenderEndpoints/README.md
@@ -4,7 +4,10 @@
 
 * Isolate machine
 * Unisolate machine
+* Restrict App Execution on a machine
+* Remove app restriction on a machine
 * Run full antivirus scan
+* Run an automated scan
 * Push IoC to Microsoft defender
   * Alert
   * BlockAndAlert


### PR DESCRIPTION
This PR contains a few fixes for this responder :

- When an organisation doesn't synchronise computers in AzureAD, the function getMachineID is not able to retrieve an id as the field AadDeviceID returns null. In this case, it retrieves the field id, which is an id provided by MDE to the machine.
- We had issues with the oauth uri, and updated the uri provided in the json files with the latest one on MS's documentation.
- Fixed the Dockerfile as the -r option was causing issues during the build.
- Fixed the malformed json body of the pushCustomIOCAlert function.


**New Features :** 

- You can now lauch an automated investigation on a device
- You can restrict the exectution of apps on the device (leaves Outlook, skype, Teams operational). Not as restrictive as device isolation. A tag is applied to the observable
- Added more IOC options to push to MDE : 
  - Hashes (MD5, SHA1 and SHA256)
  - Domains
  - Url

Also minor updates to the readme file, a new api permission is required to restrict device app execution