### PR TITLE
[FR] Added capabilities/features for Microsoft Defender O365

### DIFF
--- a/responders/MSDefenderOffice365/MSDefenderOffice365_block_sender.json
+++ b/responders/MSDefenderOffice365/MSDefenderOffice365_block_sender.json
@@ -4,7 +4,7 @@
     "author": "Joe Lazaro",
     "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
     "license": "AGPL-V3",
-    "description": "Add entries to the Tenant Allow/Block List in the Microsoft 365 Defender",
+    "description": "Block external email addresses or domains in Microsoft 365 Defender, add entries to the Tenant Allow/Block List. This will prevent communication with users in your organization (sending or receiving mail).",
     "dataTypeList": [
         "thehive:case_artifact"
     ],

--- a/responders/MSDefenderOffice365/MSDefenderOffice365_block_sender.json
+++ b/responders/MSDefenderOffice365/MSDefenderOffice365_block_sender.json
@@ -1,5 +1,5 @@
 {
-    "name": "MSDefenderOffice365_unblock",
+    "name": "MSDefenderOffice365_block_sender",
     "version": "1.0",
     "author": "Joe Lazaro",
     "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
@@ -11,7 +11,7 @@
     "command": "MSDefenderOffice365/ms_defender_office.py",
     "baseConfig": "MSDefenderOffice365",
     "config": {
-        "service": "unblock"
+        "service": "block"
     },
     "registration_required": true,
     "subscription_required": true,
@@ -55,6 +55,14 @@
             "type": "string",
             "multi": false,
             "required": true
+        },
+        {
+            "name": "block_expiration_days",
+            "description": "How many days out should we set the expiration? A value <= 0 means to set no expiration.",
+            "type": "number",
+            "multi": false,
+            "required": true,
+            "defaultValue": 0
         }
     ]
 }

--- a/responders/MSDefenderOffice365/MSDefenderOffice365_block_url.json
+++ b/responders/MSDefenderOffice365/MSDefenderOffice365_block_url.json
@@ -1,0 +1,68 @@
+{
+    "name": "MSDefenderOffice365_block_url",
+    "version": "1.0",
+    "author": "Joe Lazaro",
+    "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
+    "license": "AGPL-V3",
+    "description": "Add entries to the Tenant Allow/Block List in the Microsoft 365 Defender",
+    "dataTypeList": [
+        "thehive:case_artifact"
+    ],
+    "command": "MSDefenderOffice365/ms_defender_office.py",
+    "baseConfig": "MSDefenderOffice365",
+    "config": {
+        "service": "block"
+    },
+    "registration_required": true,
+    "subscription_required": true,
+    "free_subscription": false,
+    "service_homepage": "https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/defender-for-office-365?view=o365-worldwide",
+    "service_logo": {
+        "path": "assets/MicrosoftDefenderForOffice365_logo.png",
+        "caption": "logo"
+    },
+    "screenshots": [
+        {
+            "path": "assets/MSDefenderOffice365_Block.png",
+            "caption": "Example responder action result"
+        }
+    ],
+    "configurationItems": [
+        {
+            "name": "certificate_base64",
+            "description": "Base64-encoded PFX certificate to be used for certificate-based authentication.",
+            "type": "string",
+            "multi": false,
+            "required": true
+        },
+        {
+            "name": "certificate_password",
+            "description": "Password for the certificate used to authenticate",
+            "type": "string",
+            "multi": false,
+            "required": true
+        },
+        {
+            "name": "app_id",
+            "description": "The application ID of the service principal that's used in certificate based authentication",
+            "type": "string",
+            "multi": false,
+            "required": true
+        },
+        {
+            "name": "organization",
+            "description": "Tenant ID. Example: something.onmicrosoft.com",
+            "type": "string",
+            "multi": false,
+            "required": true
+        },
+        {
+            "name": "block_expiration_days",
+            "description": "How many days out should we set the expiration? A value <= 0 means to set no expiration.",
+            "type": "number",
+            "multi": false,
+            "required": true,
+            "defaultValue": 0
+        }
+    ]
+}

--- a/responders/MSDefenderOffice365/MSDefenderOffice365_block_url.json
+++ b/responders/MSDefenderOffice365/MSDefenderOffice365_block_url.json
@@ -1,10 +1,10 @@
 {
     "name": "MSDefenderOffice365_block_url",
     "version": "1.0",
-    "author": "Joe Lazaro",
+    "author": "Joe Lazaro, Patrick Stanullo",
     "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
     "license": "AGPL-V3",
-    "description": "Add entries to the Tenant Allow/Block List in the Microsoft 365 Defender",
+    "description": "Block a domain (URL) in Microsoft 365 Defender, add entries to the Tenant Allow/Block List. This will prevent users from accessing the webpage and receiving emails containing the URL.",
     "dataTypeList": [
         "thehive:case_artifact"
     ],

--- a/responders/MSDefenderOffice365/MSDefenderOffice365_unblock_sender.json
+++ b/responders/MSDefenderOffice365/MSDefenderOffice365_unblock_sender.json
@@ -4,7 +4,7 @@
     "author": "Joe Lazaro",
     "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
     "license": "AGPL-V3",
-    "description": "Add entries to the Tenant Allow/Block List in the Microsoft 365 Defender",
+    "description": "Unblock a email address or domain  from the Tenant Allow/Block List in the Microsoft 365 Defender",
     "dataTypeList": [
         "thehive:case_artifact"
     ],

--- a/responders/MSDefenderOffice365/MSDefenderOffice365_unblock_sender.json
+++ b/responders/MSDefenderOffice365/MSDefenderOffice365_unblock_sender.json
@@ -1,5 +1,5 @@
 {
-    "name": "MSDefenderOffice365_block",
+    "name": "MSDefenderOffice365_unblock_sender",
     "version": "1.0",
     "author": "Joe Lazaro",
     "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
@@ -11,7 +11,7 @@
     "command": "MSDefenderOffice365/ms_defender_office.py",
     "baseConfig": "MSDefenderOffice365",
     "config": {
-        "service": "block"
+        "service": "unblock"
     },
     "registration_required": true,
     "subscription_required": true,
@@ -55,14 +55,6 @@
             "type": "string",
             "multi": false,
             "required": true
-        },
-        {
-            "name": "block_expiration_days",
-            "description": "How many days out should we set the expiration? A value <= 0 means to set no expiration.",
-            "type": "number",
-            "multi": false,
-            "required": true,
-            "defaultValue": 0
         }
     ]
 }

--- a/responders/MSDefenderOffice365/MSDefenderOffice365_unblock_url.json
+++ b/responders/MSDefenderOffice365/MSDefenderOffice365_unblock_url.json
@@ -1,0 +1,60 @@
+{
+    "name": "MSDefenderOffice365_unblock_url",
+    "version": "1.0",
+    "author": "Joe Lazaro",
+    "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
+    "license": "AGPL-V3",
+    "description": "Add entries to the Tenant Allow/Block List in the Microsoft 365 Defender",
+    "dataTypeList": [
+        "thehive:case_artifact"
+    ],
+    "command": "MSDefenderOffice365/ms_defender_office.py",
+    "baseConfig": "MSDefenderOffice365",
+    "config": {
+        "service": "unblock"
+    },
+    "registration_required": true,
+    "subscription_required": true,
+    "free_subscription": false,
+    "service_homepage": "https://learn.microsoft.com/en-us/microsoft-365/security/office-365-security/defender-for-office-365?view=o365-worldwide",
+    "service_logo": {
+        "path": "assets/MicrosoftDefenderForOffice365_logo.png",
+        "caption": "logo"
+    },
+    "screenshots": [
+        {
+            "path": "assets/MSDefenderOffice365_Block.png",
+            "caption": "Example responder action result"
+        }
+    ],
+    "configurationItems": [
+        {
+            "name": "certificate_base64",
+            "description": "Base64-encoded PFX certificate to be used for certificate-based authentication.",
+            "type": "string",
+            "multi": false,
+            "required": true
+        },
+        {
+            "name": "certificate_password",
+            "description": "Password for the certificate used to authenticate",
+            "type": "string",
+            "multi": false,
+            "required": true
+        },
+        {
+            "name": "app_id",
+            "description": "The application ID of the service principal that's used in certificate based authentication",
+            "type": "string",
+            "multi": false,
+            "required": true
+        },
+        {
+            "name": "organization",
+            "description": "Tenant ID. Example: something.onmicrosoft.com",
+            "type": "string",
+            "multi": false,
+            "required": true
+        }
+    ]
+}

--- a/responders/MSDefenderOffice365/MSDefenderOffice365_unblock_url.json
+++ b/responders/MSDefenderOffice365/MSDefenderOffice365_unblock_url.json
@@ -1,10 +1,10 @@
 {
     "name": "MSDefenderOffice365_unblock_url",
     "version": "1.0",
-    "author": "Joe Lazaro",
+    "author": "Joe Lazaro, Patrick Stanullo",
     "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
     "license": "AGPL-V3",
-    "description": "Add entries to the Tenant Allow/Block List in the Microsoft 365 Defender",
+    "description": "Unblock a domain from the Tenant Allow/Block List in the Microsoft 365 Defender",
     "dataTypeList": [
         "thehive:case_artifact"
     ],

--- a/responders/MSDefenderOffice365/ms_defender_office.py
+++ b/responders/MSDefenderOffice365/ms_defender_office.py
@@ -44,7 +44,7 @@ class MsDefenderOffice365Responder(Responder):
         if not isinstance(o_data, list):
             o_data = [o_data]
 
-        if observable['dataType'] not in ['domain', 'fqdn', 'mail']:
+        if observable['dataType'] not in ['domain', 'fqdn', 'mail', 'url']:
             self.error(f"Data type {observable['dataType']} not supported.")
 
         try:

--- a/responders/MSDefenderOffice365/scripts/block_url.ps1
+++ b/responders/MSDefenderOffice365/scripts/block_url.ps1
@@ -1,0 +1,47 @@
+param (
+    [parameter(mandatory=$true)]
+    [string] $certFilePath,
+    [parameter(mandatory=$true)]
+    [string] $certPassword,
+    [parameter(mandatory=$true)]
+    [string] $appId,
+    [parameter(mandatory=$true)]
+    [string] $organization,
+    [string] $notes="",
+    [parameter(mandatory=$true)]
+    [int] $expirationLength,
+    [parameter(mandatory=$true, valueFromRemainingArguments=$true)]
+    [string[]] $entries
+)
+
+$connectSplat = @{
+    CertificateFilePath = $certFilePath
+    CertificatePassword = $(ConvertTo-SecureString -String $certPassword -AsPlainText -Force)
+    AppId = $appId
+    Organization = $organization
+}
+
+Connect-ExchangeOnline @connectSplat
+
+$allResults = @()
+ForEach ($entry in $entries) {
+    if ($expirationLength -le 0) {
+        # No expiration
+        $result = New-TenantAllowBlockListItems -ListType Url -Block -Notes $notes -Entries $entry -NoExpiration -ErrorAction Continue | ConvertTo-Json
+        $allResults += @{
+            entry = $entry;
+            result = $result;
+            error = If ($?) {$null} else {$Error[0].Exception.SerializedRemoteException.Message};
+        }
+    } else {
+        $expiry = (Get-Date).AddDays($expirationLength)
+        $result = New-TenantAllowBlockListItems -ListType Url -Block -ExpirationDate $expiry -Notes $notes -Entries $entry -ErrorAction Continue | ConvertTo-Json
+        $allResults += @{
+            entry = $entry;
+            result = $result;
+            error = If ($?) {$null} else {$Error[0].Exception.SerializedRemoteException.Message};
+        }
+    }
+}
+
+$allResults | ConvertTo-Json -Depth 4

--- a/responders/MSDefenderOffice365/scripts/unblock_url.ps1
+++ b/responders/MSDefenderOffice365/scripts/unblock_url.ps1
@@ -1,0 +1,33 @@
+param (
+    [parameter(mandatory=$true)]
+    [string] $certFilePath,
+    [parameter(mandatory=$true)]
+    [string] $certPassword,
+    [parameter(mandatory=$true)]
+    [string] $appId,
+    [parameter(mandatory=$true)]
+    [string] $organization,
+    [parameter(mandatory=$true, valueFromRemainingArguments=$true)]
+    [string[]] $entries
+)
+
+$connectSplat = @{
+    CertificateFilePath = $certFilePath
+    CertificatePassword = $(ConvertTo-SecureString -String $certPassword -AsPlainText -Force)
+    AppId = $appId
+    Organization = $organization
+}
+
+Connect-ExchangeOnline @connectSplat
+
+$allResults = @()
+ForEach ($entry in $entries) {
+    $result = Remove-TenantAllowBlockListItems -ListType Sender -Entries $entry | ConvertTo-Json
+    $allResults += @{
+        entry = $entry;
+        result = $result;
+        error = If ($?) {$null} else {$Error[0].Exception.SerializedRemoteException.Message};
+    }
+}
+
+$allResults | ConvertTo-Json -Depth 4

--- a/responders/MSDefenderOffice365/scripts/unblock_url.ps1
+++ b/responders/MSDefenderOffice365/scripts/unblock_url.ps1
@@ -22,7 +22,7 @@ Connect-ExchangeOnline @connectSplat
 
 $allResults = @()
 ForEach ($entry in $entries) {
-    $result = Remove-TenantAllowBlockListItems -ListType Sender -Entries $entry | ConvertTo-Json
+    $result = Remove-TenantAllowBlockListItems -ListType Url -Entries $entry | ConvertTo-Json
     $allResults += @{
         entry = $entry;
         result = $result;


### PR DESCRIPTION
I have slightly revised the existing "Microsoft Defender Office 365" responder and added a new function. Previously, this responder was intended to block malicious sender domains and email addresses. However, the "Tenant Allow/Blocklist" has even more features that I wanted to use. 

### The following have been revised:
- Descriptions and names of the responders to make it easier to understand what they do

Example "MSDefenderOffice365_block_1_0" -> "MSDefenderOffice365_block_**sender**_1_0"

### New feature:
- The possibility to add domain, fqdn or URL to the "URL" list. ("Block a URL to stop users from accessing the webpage and prevent the delivery of emails containing the URL.) 
- "MSDefenderOffice365_block_url_1_0"

A possible use case of this feature: QR phishing links can be blocked directly if the Defender for iOS has been installed. In my test, after blocking the domain, it was almost immediately no longer possible to access the URL on the iPhone.
