### PR TITLE
Update opencti.py

### DIFF
--- a/analyzers/OpenCTI/opencti.py
+++ b/analyzers/OpenCTI/opencti.py
@@ -78,13 +78,14 @@ class OpenCTIAnalyzer(Analyzer):
 
                 # Get a list of reports containing this observable
                 reports = opencti["api_client"].report.list(
-                    filters=[
-                        {
-                            "key": "objectContains",
-                            "values": [observable["id"]],
-                        }
-                    ]
-                )
+                       filters={
+                            "mode": "and",
+                            "filters": [{"key": "objects", "values": [observable["id"]]}],
+                            "filterGroups": [],
+                                },
+                            orderBy="published",
+                            orderMode="asc",
+                        )
 
                 # Strip reports data for lighter output.
                 for report in reports:


### PR DESCRIPTION
We installed OpenCTI and realized that the Analyzer is no longer working.  Failing with error: got invalid value [{ key: \"objectContains\", values: [Array] }]; Field \"mode\" of required type \"FilterMode!\" was not provided. I looked at the examples here: https://github.com/OpenCTI-Platform/client-python/blob/master/examples/get_reports_about_intrusion_set.py and tried to repair the analyzer.