### PR TITLE
KasperskyTIP fix: previously ignored category orange now is malicious

### DIFF
--- a/analyzers/KasperskyTIP/KasperskyTIP.py
+++ b/analyzers/KasperskyTIP/KasperskyTIP.py
@@ -20,7 +20,7 @@ class KasperskyTIP(Analyzer):
             level = "safe"
         elif value == "Yellow":
             level = "suspicious"
-        elif value == "Red":
+        elif value in ["Orange", "Red"]:
             level = "malicious"
         taxonomies.append(self.build_taxonomy(level, namespace, predicate, value))
         return {'taxonomies': taxonomies}


### PR DESCRIPTION
Every time an observable is classified in the Orange zone, it is tagged as "Info". As per the documentation [here](https://opentip.kaspersky.com/Help/Doc_data/AboutZones.htm), it should be classified as Malicious.