### PR TITLE
PhishTank fix: add User-Agent header to make phishtank api work again

### DIFF
--- a/analyzers/PhishTank/phishtank_checkurl.py
+++ b/analyzers/PhishTank/phishtank_checkurl.py
@@ -13,8 +13,9 @@ class PhishtankAnalyzer(Analyzer):
 
     def phishtank_checkurl(self, data):
         url = 'https://checkurl.phishtank.com/checkurl/'
+        postheaders = {"User-Agent": "phishtank/cortex"}
         postdata = {'url': data, 'format': 'json', 'app_key': self.phishtank_key}
-        r = requests.post(url, data=postdata)
+        r = requests.post(url, headers=postheaders, data=postdata)
         return r.json()
 
     def summary(self, raw):


### PR DESCRIPTION
As per the documentation [here](https://phishtank.org/api_info.php), the API now needs a User-Agent header in the request. A dummy one that is compliant with the accepted format should suffice.