### PR TITLE
SpamHausDBL fix: replace query function (not working) with resolve function

### DIFF
--- a/analyzers/SpamhausDBL/spamhausdbl.py
+++ b/analyzers/SpamhausDBL/spamhausdbl.py
@@ -26,7 +26,7 @@ class SpamhausDBLAnalyzer(Analyzer):
    
     def run(self):
         try:
-            lookup = dns.resolver.query(self.observable + '.dbl.spamhaus.org')
+            lookup = dns.resolver.resolve(self.observable + '.dbl.spamhaus.org')
             return_code = str(lookup[0])
             # Check return code for result info
             # Reference here: https://www.spamhaus.org/faq/section/Spamhaus%20DBL#291


### PR DESCRIPTION
The query() function does not work anymore with recent versions of Python (as it is in the containerized neuron). It was replaced with the resolve() function, which makes the analyzer work again as expected.