### PR TITLE
Pin thehive4py package version to 1.8.x

### DIFF
--- a/responders/MailIncidentStatus/requirements.txt
+++ b/responders/MailIncidentStatus/requirements.txt
@@ -1,2 +1,2 @@
 cortexutils
-thehive4py
+thehive4py~=1.8.1

--- a/responders/PaloAltoNGFW/requirements.txt
+++ b/responders/PaloAltoNGFW/requirements.txt
@@ -1,4 +1,4 @@
 cortexutils
 requests
 pan-os-python
-thehive4py
+thehive4py~=1.8.1

--- a/responders/Velociraptor/requirements.txt
+++ b/responders/Velociraptor/requirements.txt
@@ -2,4 +2,4 @@ cortexutils
 cryptography
 grpcio-tools
 pyvelociraptor
-thehive4py
+thehive4py~=1.8.1

--- a/responders/VirustotalDownloader/requirements.txt
+++ b/responders/VirustotalDownloader/requirements.txt
@@ -1,6 +1,6 @@
 cortexutils
 datetime
 requests
-thehive4py
+thehive4py~=1.8.1
 python-magic
 filetype


### PR DESCRIPTION
Fixes #1281: Pin the version of thehive4py to 1.8.x to ensure compatibility. This change uses the version specifier ~=1.8.1 in all requirements.txt files to allow updates within the 1.8 minor series, while avoiding breaking changes in future major versions.