### PR TITLE
Domaintools dependency issues

### DIFF
--- a/analyzers/DomainTools/requirements.txt
+++ b/analyzers/DomainTools/requirements.txt
@@ -1,3 +1,2 @@
 cortexutils
-domaintools_api ; python_version < '3.5'
-git+https://github.com/DomainTools/python_api.git ; python_version >= '3.5'
+domaintools_api==0.6.2

--- a/analyzers/DomainToolsIris/requirements.txt
+++ b/analyzers/DomainToolsIris/requirements.txt
@@ -1,3 +1,2 @@
 cortexutils
-domaintools_api ; python_version < '3.5'
-git+https://github.com/DomainTools/python_api.git ; python_version >= '3.5'
+domaintools_api==0.6.2


### PR DESCRIPTION
Analyzers do not work with latest versions of domaintools-api, whether it is domaintools-api 1.x or 2.x