### PR TITLE
Capa Analyzer - auto-download latest capa binary

### DIFF
--- a/analyzers/Capa/Dockerfile
+++ b/analyzers/Capa/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3
+WORKDIR /worker
+COPY . Capa
+
+# Install required tools
+RUN apt-get update && apt-get install -y \
+    curl \
+    jq \
+    unzip && \
+    rm -rf /var/lib/apt/lists/*
+
+# Add a script to fetch the latest capa release and extract it
+COPY fetch_capa.sh /worker/fetch_capa.sh
+RUN chmod +x /worker/fetch_capa.sh && /worker/fetch_capa.sh
+
+RUN test ! -e Capa/requirements.txt || pip install --no-cache-dir -r Capa/requirements.txt
+ENTRYPOINT "Capa/CapaAnalyze.py"

--- a/analyzers/Capa/fetch_capa.sh
+++ b/analyzers/Capa/fetch_capa.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e  # Exit immediately if a command exits with a non-zero status
+set -x  # Print commands and their arguments as they are executed
+
+# Fetch the latest release version
+LATEST_VERSION=$(curl -s https://api.github.com/repos/mandiant/capa/releases/latest | jq -r '.tag_name')
+
+# Validate the version
+if [ -z "$LATEST_VERSION" ]; then
+    echo "Failed to fetch the latest version."
+    exit 1
+fi
+
+echo "Latest version is $LATEST_VERSION"
+
+# Construct the download URL
+DOWNLOAD_URL="https://github.com/mandiant/capa/releases/download/${LATEST_VERSION}/capa-${LATEST_VERSION}-linux.zip"
+echo "Downloading from $DOWNLOAD_URL"
+
+# Download and extract capa
+curl -L -o capa.zip "$DOWNLOAD_URL" || { echo "Download failed"; exit 1; }
+unzip capa.zip -d /worker/capa || { echo "Extraction failed"; exit 1; }
+
+# Clean up
+rm capa.zip
+echo "Capa downloaded and extracted successfully."


### PR DESCRIPTION
This PR:

- Removes the need to keep the capa binary in the repository.
- Implements an auto-download mechanism to fetch the latest capa binary during each build.