### PR TITLE
New Analyzer & Responders Watcher

### DIFF
--- a/analyzers/Watcher/README.md
+++ b/analyzers/Watcher/README.md
@@ -1,0 +1,53 @@
+# [Watcher](https://github.com/thalesgroup-cert/Watcher)
+
+## Watcher Check Domain Analyzer
+
+### Description
+The Watcher Check Domain Analyzer is an Analyzer for TheHive/Cortex that checks if a given domain is already being monitored in the Watcher website monitoring system.
+
+### Features
+- **Check if a domain is monitored**: Verifies whether a specific domain is already being monitored in the Watcher system.
+
+### Prerequisites
+- Access to the Watcher API
+- A valid API key for Watcher
+- A functional instance of Cortex and TheHive
+
+### Installation
+- Add the configuration files for this analyzer to your Cortex configuration.
+
+### Configuration
+In Cortex, configure the following parameters for the Analyzer:
+
+| Parameter          | Description                                                        | Required | Default Value |
+|--------------------|--------------------------------------------------------------------|----------|----------------|
+| `watcher_url`      | URL of Watcher (e.g. `https://example.watcher.local:9002`)         | Yes      | -              |
+| `watcher_api_key`  | API key for authenticating                                         | Yes      | -              |
+
+### Usage
+When a domain artifact is submitted to this analyzer, it will:
+1. Query the Watcher API to check if the domain is already monitored.
+2. Return a report with either the monitoring status of the domain or an indication that it is not yet monitored.
+
+### Example JSON Response
+#### Domain is already monitored
+```json
+{
+  "status": "Monitored",
+  "Message": "Domain 'example.com' is already monitored in Watcher.",
+  "ticket_id": "12345"
+}
+```
+
+#### Domain is not monitored
+```json
+{
+  "status": "Not Monitored",
+  "Message": "Domain 'example.com' is not monitored in Watcher. You can add it using the Watcher responder."
+}
+```
+
+### Author
+
+**Thales Group CERT** - [thalesgroup-cert on GitHub](https://github.com/thalesgroup-cert)  
+**Ygal NEZRI** - [@ygalnezri](https://github.com/ygalnezri)

--- a/analyzers/Watcher/Watcher_CheckDomain.json
+++ b/analyzers/Watcher/Watcher_CheckDomain.json
@@ -1,0 +1,26 @@
+{
+    "name": "Watcher_CheckDomain",
+    "version": "1.2",
+    "author": "THA-CERT // YNE",
+    "url": "-",
+    "license": "AGPL-V3",
+    "description": "Checks if a domain is monitored in Watcher.",
+    "dataTypeList": ["domain"],
+    "command": "Watcher/watcher.py",
+    "baseConfig": "Watcher",
+    "configurationItems": [
+      {
+        "name": "watcher_url",
+        "description": "URL of Watcher.",
+        "type": "string",
+        "required": true
+      },
+      {
+        "name": "watcher_api_key",
+        "description": "API key used for authenticating requests to Watcher.",
+        "type": "string",
+        "required": true
+      }
+    ]
+  }
+  

--- a/analyzers/Watcher/requirements.txt
+++ b/analyzers/Watcher/requirements.txt
@@ -1,0 +1,2 @@
+cortexutils
+requests

--- a/analyzers/Watcher/watcher.py
+++ b/analyzers/Watcher/watcher.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+# Author: THA-CERT // YNE
+
+import requests
+import json
+from cortexutils.analyzer import Analyzer
+
+class Watcher_CheckDomain(Analyzer):
+    def __init__(self):
+        super(Watcher_CheckDomain, self).__init__()
+
+        # Load URL and API key from config
+        base_url = self.get_param("config.watcher_url", None, "Watcher URL is missing.")
+        self.watcher_url = f"{base_url.rstrip('/')}/api/site_monitoring/site/"
+        self.watcher_api_key = self.get_param("config.watcher_api_key", None, "Watcher API key is missing.")
+
+        # Set headers
+        self.headers = {
+            "Authorization": f"Token {self.watcher_api_key}",
+            "Content-Type": "application/json"
+        }
+
+    def check_domain_status(self, domain):
+        """Check if the domain is already being monitored in Watcher."""
+        try:
+            response = requests.get(
+                self.watcher_url,
+                headers=self.headers,
+                verify=False
+            )
+            response.raise_for_status()
+            sites = response.json()
+
+            for site in sites:
+                if site.get("domain_name") == domain:
+                    return True, site.get("ticket_id")
+            return False, None
+        except requests.exceptions.RequestException as e:
+            self.error(f"API request error while checking monitored domains: {str(e)}")
+            return None, None
+
+    def summary(self, raw):
+        """Generate a summary for TheHive taxonomies."""
+        taxonomies = []
+        namespace = "Watcher"
+        predicate = "Check"
+        status = raw.get("status", "Not Monitored")
+
+        level = "safe" if status == "Monitored" else "info"
+        taxonomies.append(self.build_taxonomy(level, namespace, predicate, status))
+
+        return {"taxonomies": taxonomies}
+
+    def run(self):
+        try:
+            data = self.get_data()
+
+            if not data:
+                self.error("No data received from Cortex. Cannot proceed.")
+                return
+            if isinstance(data, str):
+                try:
+                    if data.strip() and not data.startswith("{"):
+                        data = json.loads(f'{{"data": "{data}"}}')
+                except json.JSONDecodeError as e:
+                    self.error(f"Invalid JSON received from Cortex. Input received: {data}. Error: {str(e)}")
+                    return
+
+            domain = data.get("data")
+
+            if not domain or not isinstance(domain, str):
+                self.error("Invalid input: Domain name is missing or not a string.")
+                return
+
+            is_monitored, ticket_id = self.check_domain_status(domain)
+
+            if is_monitored:
+                status = "Monitored"
+                message = {
+                    "status": status,
+                    "Message": f"Domain '{domain}' is already monitored in Watcher.",
+                    "ticket_id": ticket_id
+                }
+            else:
+                status = "Not Monitored"
+                message = {
+                    "status": status,
+                    "Message": f"Domain '{domain}' is not monitored in Watcher. You can add it using the Watcher responder."
+                }
+
+            self.report(message)
+        except Exception as e:
+            self.error(f"Unexpected error: {str(e)}")
+
+if __name__ == "__main__":
+    Watcher_CheckDomain().run()

--- a/responders/Watcher/README.md
+++ b/responders/Watcher/README.md
@@ -1,0 +1,55 @@
+# [Watcher](https://github.com/thalesgroup-cert/Watcher)
+
+## Watcher Monitor Manager Responder
+
+### Description
+Watcher Monitor Manager is a Responder for TheHive/Cortex that allows adding or removing a domain from monitoring in the Watcher website monitoring module.
+
+### Features
+- **Add a domain to monitoring** (`WatcherAddDomain`)
+- **Remove a domain from monitoring** (`WatcherRemoveDomain`)
+
+### Prerequisites
+- Access to the Watcher API
+- A valid API key of Watcher
+- A functional instance of Cortex and TheHive
+
+### Installation
+- Add the configuration files (`Watcher_Add_Domain.json` and `Watcher_Remove_Domain.json`) to the Cortex configurations.
+
+### Configuration
+In Cortex, configure the following parameters for the Responder:
+
+| Parameter               | Description                                                              | Required | Default Value |
+|-------------------------|--------------------------------------------------------------------------|----------|----------------|
+| `watcher_url`           | URL of Watcher (e.g. `https://example.watcher.local:9002`)           | Yes      | -              |
+| `watcher_api_key`       | API key for authentication                                               | Yes      | -              |
+| `the_hive_custom_field` | Name of the custom field (same as .env variable)                         | Yes      | `watcher-id`   |
+
+### Usage
+When an artifact of type `domain` is submitted to this Responder, it will:
+1. Extract the Watcher ID from the `customFieldValues` of the alert or case.
+2. Perform the requested action (`add` or `remove`) based on the specified service.
+3. Return a report indicating the success or failure of the operation.
+
+### Example JSON Response
+#### Adding a Domain
+```json
+{
+  "Message": "Domain 'example.com' successfully added to monitoring with watcher-id: '12345'.",
+  "WatcherResponse": {"status": "success"}
+}
+```
+
+#### Removing a Domain
+```json
+{
+  "Message": "Domain 'example.com' successfully removed from monitoring.",
+  "WatcherResponse": {"status": "success"}
+}
+```
+
+### Author
+
+**Thales Group CERT** - [thalesgroup-cert on GitHub](https://github.com/thalesgroup-cert)  
+**Ygal NEZRI** - [@ygalnezri](https://github.com/ygalnezri)

--- a/responders/Watcher/Watcher_Add_Domain.json
+++ b/responders/Watcher/Watcher_Add_Domain.json
@@ -1,0 +1,35 @@
+{
+  "name": "Watcher_Add_Domain",
+  "version": "1.2",
+  "author": "THA-CERT // YNE",
+  "url": "https://github.com/thalesgroup-cert/Watcher",
+  "license": "AGPL-V3",
+  "description": "Add a domain to monitoring in the Website Monitoring module on Watcher.",
+  "dataTypeList": ["thehive:case_artifact"],
+  "command": "Watcher/watcher.py",
+  "baseConfig": "Watcher",
+  "config": {
+    "service": "WatcherAddDomain"
+  },
+  "configurationItems": [
+    {
+      "name": "watcher_url",
+      "description": "URL of Watcher.",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "watcher_api_key",
+      "description": "API key used for authenticating requests to Watcher.",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "the_hive_custom_field",
+      "description": "Name of the custom field (same as .env variable).",
+      "type": "string",
+      "required": true,
+      "defaultValue": "watcher-id"
+    }
+  ]
+}

--- a/responders/Watcher/Watcher_Remove_Domain.json
+++ b/responders/Watcher/Watcher_Remove_Domain.json
@@ -1,0 +1,35 @@
+{
+  "name": "Watcher_Remove_Domain",
+  "version": "1.2",
+  "author": "THA-CERT // YNE",
+  "url": "https://github.com/thalesgroup-cert/Watcher",
+  "license": "AGPL-V3",
+  "description": "Removes a domain from monitoring in the Website Monitoring module on Watcher.",
+  "dataTypeList": ["thehive:case_artifact"],
+  "command": "Watcher/watcher.py",
+  "baseConfig": "Watcher",
+  "config": {
+    "service": "WatcherRemoveDomain"
+  },
+  "configurationItems": [
+    {
+      "name": "watcher_url",
+      "description": "URL of Watcher.",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "watcher_api_key",
+      "description": "API key used for authenticating requests to Watcher.",
+      "type": "string",
+      "required": true
+    },
+    {
+      "name": "the_hive_custom_field",
+      "description": "Name of the custom field (same as .env variable).",
+      "type": "string",
+      "required": true,
+      "defaultValue": "watcher-id"
+    }
+  ]
+}

--- a/responders/Watcher/requirements.txt
+++ b/responders/Watcher/requirements.txt
@@ -1,0 +1,2 @@
+cortexutils
+requests

--- a/responders/Watcher/watcher.py
+++ b/responders/Watcher/watcher.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+# Author: THA-CERT // YNE
+
+import requests
+import json
+from cortexutils.responder import Responder
+
+class Watcher_MonitorManager(Responder):
+    def __init__(self):
+        super(Watcher_MonitorManager, self).__init__()
+
+        # Load URL and API key from config
+        base_url = self.get_param("config.watcher_url", None, "Watcher URL is missing.")
+        self.watcher_url = f"{base_url.rstrip('/')}/api/site_monitoring/site/"
+        self.watcher_api_key = self.get_param("config.watcher_api_key", None, "Watcher API key is missing.")
+        self.the_hive_custom_field = self.get_param("config.the_hive_custom_field", "watcher-id", "Custom Field is missing.")
+        self.service = self.get_param("config.service", None, "Service parameter is missing.")
+
+        # Set headers
+        self.headers = {
+            "Authorization": f"Token {self.watcher_api_key}",
+            "Content-Type": "application/json"
+        }
+
+    def validate_artifact(self, data):
+        """Validate if the artifact type is supported (only 'domain' is accepted)."""
+        domain = data.get("data", None)
+        artifact_type = data.get("dataType", None)
+
+        if artifact_type != "domain":
+            return False, None
+
+        return True, domain
+
+    def extract_source_ref(self, data):
+        """Extract sourceRef (watcher-id) from the provided data, if available."""
+        container = data.get("alert") or data.get("case", {})
+        custom_fields = container.get("customFieldValues", {})
+        return custom_fields.get(self.the_hive_custom_field, None)
+
+    def is_domain_already_monitored(self, domain):
+        """Check if the domain is already being monitored."""
+        try:
+            response = requests.get(
+                self.watcher_url,
+                headers=self.headers,
+                verify=False
+            )
+            response.raise_for_status()
+            sites = response.json()
+
+            for site in sites:
+                if site.get("domain_name") == domain:
+                    self.error(f"Domain '{domain}' already exists in Watcher and is being monitored.")
+                    return True
+            return False
+        except requests.exceptions.RequestException as e:
+            self.error(f"API request error while checking monitored domains: {str(e)}")
+            return False
+
+    def add_monitor(self, domain, source_ref):
+        """Add a domain to monitoring."""
+        if self.is_domain_already_monitored(domain):
+            return
+
+        payload = {
+            "action": "add",
+            "domain_name": domain,
+            "ticket_id": source_ref
+        }
+
+        try:
+            response = requests.post(
+                self.watcher_url,
+                headers=self.headers,
+                json=payload,
+                verify=False,
+            )
+            response.raise_for_status()
+
+            response_data = response.json() if response.content else {}
+
+            return {
+                "Message": f"Domain '{domain}' successfully added to monitoring with {self.the_hive_custom_field}: '{source_ref}'.",
+                "WatcherResponse": response_data
+            }
+        except requests.exceptions.RequestException as e:
+            self.error(f"Failed to add domain '{domain}' to monitoring: {str(e)}")
+
+    def get_site_id(self, domain):
+        """Get the site ID associated with a given domain."""
+        try:
+            response = requests.get(
+                self.watcher_url,
+                headers=self.headers,
+                verify=False
+            )
+            response.raise_for_status()
+            sites = response.json()
+
+            for site in sites:
+                if site.get("domain_name") == domain:
+                    return site.get("id")
+
+            self.error(f"Domain '{domain}' not found in Watcher.")
+        except requests.exceptions.RequestException as e:
+            self.error(f"API request error while fetching site ID for domain '{domain}': {str(e)}")
+        return None
+
+    def remove_monitor(self, domain, source_ref):
+        """Remove a domain from monitoring."""
+        site_id = self.get_site_id(domain)
+        if not site_id:
+            self.error(f"Unable to retrieve site ID for domain '{domain}'.")
+
+        try:
+            response = requests.delete(
+                f"{self.watcher_url}{site_id}/",
+                headers=self.headers,
+                verify=False
+            )
+            response.raise_for_status()
+
+            response_data = response.json() if response.content else {}
+
+            return {
+                "Message": f"Domain '{domain}' successfully removed from monitoring.",
+                "WatcherResponse": response_data
+            }
+        except requests.exceptions.RequestException as e:
+            self.error(f"Failed to remove domain '{domain}' from monitoring: {str(e)}")
+
+    def run(self):
+        Responder.run(self)
+        artifact_data = self.get_data()
+
+        is_valid, domain = self.validate_artifact(artifact_data)
+        if not is_valid:
+            self.error("Invalid observable data type. Only 'domain' is supported.")
+
+        source_ref = self.extract_source_ref(artifact_data)
+        if not source_ref:
+            self.error(f"Missing {self.the_hive_custom_field} in the provided data.")
+
+        if self.service == "WatcherAddDomain":
+            report = self.add_monitor(domain, source_ref)
+        elif self.service == "WatcherRemoveDomain":
+            report = self.remove_monitor(domain, source_ref)
+        else:
+            self.error("Invalid service specified.")
+
+        # Send the report
+        self.report(report)
+
+if __name__ == "__main__":
+    Watcher_MonitorManager().run()


### PR DESCRIPTION
This PR introduces two new tools for Cortex related to the [Watcher - Open Source Cybersecurity Threat Hunting Platform.](https://github.com/thalesgroup-cert/Watcher/)

**1. Watcher Check Domain Analyzer:**

This analyzer allows TheHive/Cortex to check if a given domain is already being monitored by Watcher. Its main feature is to quickly verify the monitoring status of a domain.

**2. Watcher Monitor Manager Responder:**

This responder enables TheHive/Cortex to manage the monitoring of domains within Watcher. It provides two main features:

* **Add a domain to monitoring (WatcherAddDomain)**
* **Remove a domain from monitoring (WatcherRemoveDomain)**

These tools together provide a way to both check the current monitoring status of a domain in Watcher and to take action to add or remove a domain from monitoring directly from TheHive/Cortex.