### PR TITLE
Elasticsearch Analyzer: Fix deprecated timeout constructor argument

### DIFF
--- a/analyzers/Elasticsearch/elk.py
+++ b/analyzers/Elasticsearch/elk.py
@@ -145,7 +145,7 @@ class ElasticsearchAnalyzer(Analyzer):
                         api_key = (key),
                         ca_certs=self.cert,
                         verify_certs=self.verify,
-                        timeout=30
+                        request_timeout=30
                     )
                 elif user:
                     es = Elasticsearch(
@@ -153,14 +153,14 @@ class ElasticsearchAnalyzer(Analyzer):
                         http_auth = (user,password),
                         ca_certs=self.cert,
                         verify_certs=self.verify,
-                        timeout=30
+                        request_timeout=30
                     )
                 else:
                     es = Elasticsearch(
                         endpoint,
                         ca_certs=self.cert,
                         verify_certs=self.verify,
-                        timeout=30
+                        request_timeout=30
                     )
 
                 info = {}

--- a/analyzers/Elasticsearch/requirements.txt
+++ b/analyzers/Elasticsearch/requirements.txt
@@ -1,4 +1,4 @@
-elasticsearch
+elasticsearch>=8.0.0
 cortexutils
 pytz
 requests


### PR DESCRIPTION
**Problem**: On a new install, the Elasticsearch analyzer fails fresh out of the box. 

**Reasons**: 

* The `Elasticsearch()` constructor uses the deprecated argument `timeout`, which has been replaced by `request_timeout` with version 8.0.0 in February 2022.
* The requirements.txt has no version assigned to the elasticsearch package

See: [elasticsearch-py v8.0.0 release notes](https://github.com/elastic/elasticsearch-py/releases/tag/v8.0.0)

PR fixes:

* Changes the constructor value from `timeout` to `request_timeout`
* indicates the minimum version for the `elasticsearch-py`package