### PR TITLE
Velociraptor - support for b64 api configuration for SaaS deployments

### DIFF
--- a/responders/Velociraptor/README.md
+++ b/responders/Velociraptor/README.md
@@ -2,11 +2,21 @@
 This responder can be used to run a flow for a Velociraptor artifact.  This could include gathering data, or performing initial response, as the artifact (or artifact "pack") could encompass any number of actions.  The responder can be run on an observable type of `ip`, `fqdn`, or `other`, and will look for a matching client via the Velociraptor server.  If a client match is found for the last seen IP, or the hostname, the responder will kick off the flow, the results will be returned, and the client ID will be added as a tag to the case and the observable.
 
 #### Requirements
-The following options are required in the Velociraptor Responder configuration:   
+The following options are required in the Velociraptor Responder configuration:
 
-- `velociraptor_client_config`: The path to the Velociraptor API client config.  
-(See the following for generating an API client config: https://www.velocidex.com/docs/user-interface/api/, and ensure the appropriate ACLs are granted to the API user).  
-- `velociraptor_artifact`: The name artifact you which to collect (as you would see it in the Velociraptor GUI).
-- `upload_flow_results`: Upload flow results to TheHive case (bool).
-- `thehive_url`: URL of your TheHive installation (e.g. 'http://127.0.0.1:9000').
-- `thehive_apikey`: TheHive API key used to add flow results/file(s) to a case.
+**API Client Configuration** (choose one):
+- `velociraptor_client_config`: The path to the Velociraptor API client config file.
+- `velociraptor_client_config_content_base64`: Base64-encoded API client config (recommended for SaaS/containerized deployments).
+
+To generate an API client config, see: https://www.velocidex.com/docs/user-interface/api/
+Ensure the appropriate ACLs are granted to the API user.
+
+For SaaS deployments, encode your API client config:
+```bash
+cat api_client.yaml | base64
+```
+Then paste the output into the `velociraptor_client_config_content_base64` parameter.
+
+**Other Parameters**:
+- `velociraptor_artifact`: The name of the artifact you wish to collect (as you would see it in the Velociraptor GUI). **Required**.
+- `query_max_duration`: Max query duration in seconds (default: 600). **Optional**.

--- a/responders/Velociraptor/requirements.txt
+++ b/responders/Velociraptor/requirements.txt
@@ -2,4 +2,3 @@ cortexutils
 cryptography
 grpcio-tools
 pyvelociraptor
-thehive4py~=1.8.1

--- a/responders/Velociraptor/velociraptor_flow.json
+++ b/responders/Velociraptor/velociraptor_flow.json
@@ -14,8 +14,14 @@
       "description": "Path to API client config file",
       "type": "string",
       "multi": false,
-      "required": true,
-      "defaultValue": ""
+      "required": false
+    },
+    {
+      "name": "velociraptor_client_config_content_base64",
+      "description": "Base64-encoded API client config file (YAML format). Recommended for SaaS/containerized deployments to preserve multiline YAML structure. Generate with: cat api_client.yaml | base64",
+      "type": "string",
+      "multi": false,
+      "required": false
     },
     {
       "name": "velociraptor_artifact",


### PR DESCRIPTION
For SaaS deployments, you can now encode your API client config:
```bash
cat api_client.yaml | base64
```
Then paste the output into the `velociraptor_client_config_content_base64` parameter.