### PR TITLE
Initial commit - MSDefenderForEndpoint analyzers v1 (device lookup & hash reputation)

### DIFF
--- a/analyzers/MSDefenderForEndpoint/MSDefenderForEndpoint_DeviceLookup.json
+++ b/analyzers/MSDefenderForEndpoint/MSDefenderForEndpoint_DeviceLookup.json
@@ -1,0 +1,41 @@
+{
+  "name": "MSDefenderForEndpoint_DeviceLookup",
+  "version": "1.0",
+  "author": "Elina Galvao, StrangeBee",
+  "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
+  "license": "AGPL-V3",
+  "description": "Look up a device (by IP or hostname/FQDN) in Microsoft Defender for Endpoint: risk score, exposure level, health status and related alerts.",
+  "dataTypeList": ["ip", "fqdn"],
+  "baseConfig": "MSDefenderForEndpoint",
+  "command": "MSDefenderForEndpoint/msdefender_for_endpoint.py",
+  "config": {
+    "service": "device_lookup",
+    "check_tlp": true,
+    "max_tlp": 2,
+    "check_pap": true,
+    "max_pap": 2
+  },
+  "configurationItems": [
+    {
+      "name": "tenant_id",
+      "description": "Azure AD tenant ID",
+      "type": "string",
+      "multi": false,
+      "required": true
+    },
+    {
+      "name": "client_id",
+      "description": "Azure AD application (client) ID granted Machine.Read.All and Alert.Read.All permissions on the WindowsDefenderATP API",
+      "type": "string",
+      "multi": false,
+      "required": true
+    },
+    {
+      "name": "client_secret",
+      "description": "Azure AD application client secret",
+      "type": "string",
+      "multi": false,
+      "required": true
+    }
+  ]
+}

--- a/analyzers/MSDefenderForEndpoint/MSDefenderForEndpoint_HashReputation.json
+++ b/analyzers/MSDefenderForEndpoint/MSDefenderForEndpoint_HashReputation.json
@@ -1,0 +1,41 @@
+{
+  "name": "MSDefenderForEndpoint_HashReputation",
+  "version": "1.0",
+  "author": "Elina Galvao, StrangeBee",
+  "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
+  "license": "AGPL-V3",
+  "description": "Check a file hash (SHA1 or SHA256) against Microsoft Defender for Endpoint: organization prevalence and related alerts.",
+  "dataTypeList": ["hash"],
+  "baseConfig": "MSDefenderForEndpoint",
+  "command": "MSDefenderForEndpoint/msdefender_for_endpoint.py",
+  "config": {
+    "service": "hash_reputation",
+    "check_tlp": true,
+    "max_tlp": 2,
+    "check_pap": true,
+    "max_pap": 2
+  },
+  "configurationItems": [
+    {
+      "name": "tenant_id",
+      "description": "Azure AD tenant ID",
+      "type": "string",
+      "multi": false,
+      "required": true
+    },
+    {
+      "name": "client_id",
+      "description": "Azure AD application (client) ID granted File.Read.All and Alert.Read.All permissions on the WindowsDefenderATP API",
+      "type": "string",
+      "multi": false,
+      "required": true
+    },
+    {
+      "name": "client_secret",
+      "description": "Azure AD application client secret",
+      "type": "string",
+      "multi": false,
+      "required": true
+    }
+  ]
+}

--- a/analyzers/MSDefenderForEndpoint/README.md
+++ b/analyzers/MSDefenderForEndpoint/README.md
@@ -1,0 +1,48 @@
+# MSDefenderForEndpoint Analyzer
+
+Queries Microsoft Defender for Endpoint (MDE) to enrich observables with endpoint telemetry:
+device risk/exposure/health, and file hash prevalence and related alerts within your organization.
+
+Two flavors share the same Azure AD app registration:
+
+- **DeviceLookup**: `ip` or `fqdn` → device risk score, exposure level, health status, OS platform and related alerts.
+- **HashReputation**: `hash` (SHA1 or SHA256 only) → organization prevalence and related alerts.
+
+## Requirements
+
+1. In Azure AD, register an application (App registrations).
+2. Grant it **Application** permissions on the `WindowsDefenderATP` API:
+   - `Machine.Read.All`
+   - `Alert.Read.All`
+   - `File.Read.All`
+3. Grant admin consent for these permissions.
+4. Create a client secret for the application.
+5. Note the tenant ID, client (application) ID, and client secret.
+
+## Configuration
+
+| Parameter       | Description                                    | Required |
+|-----------------|-------------------------------------------------|----------|
+| `tenant_id`     | Azure AD tenant ID                              | Yes      |
+| `client_id`     | Azure AD application (client) ID                | Yes      |
+| `client_secret` | Azure AD application client secret              | Yes      |
+
+## Supported Observable Types
+
+- **DeviceLookup**: `ip`, `fqdn`
+- **HashReputation**: `hash` (only SHA1/SHA256 — MD5 is not supported by the MDE files API)
+
+## Output
+
+### DeviceLookup
+
+- `MDE:RiskScore="None|Low|Medium|High"` — mapped to `info`/`safe`/`suspicious`/`malicious`
+- `MDE:Alerts="<count>"` (`suspicious`) when the device has related alerts
+- `MDE:Device="NotFound"` (`info`) when no matching device is found
+
+### HashReputation
+
+- `MDE:Alerts="<count>"` — `malicious` if any related alert has High severity, `suspicious` for
+  Medium/Low/Informational alerts, `safe` if the file was seen but has no alerts, `info` otherwise
+- `MDE:OrgPrevalence="<count>"` — how many devices in your organization have seen this file
+- `MDE:File="NotSeen"` (`info`) when the hash is unknown to Microsoft Defender for Endpoint

--- a/analyzers/MSDefenderForEndpoint/msdefender_for_endpoint.py
+++ b/analyzers/MSDefenderForEndpoint/msdefender_for_endpoint.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import requests
+from cortexutils.analyzer import Analyzer
+
+
+class MSDefenderForEndpointAnalyzer(Analyzer):
+
+    LOGIN_URL = "https://login.microsoftonline.com/{}/oauth2/v2.0/token"
+    API_BASE = "https://api.security.microsoft.com/api"
+    # MDE tokens must be issued for the legacy "securitycenter" resource even when
+    # calling the api.security.microsoft.com host, otherwise requests fail with
+    # 403 Forbidden. See "Get an access token" in:
+    # https://learn.microsoft.com/en-us/defender-endpoint/api/exposed-apis-create-app-webapp
+    TOKEN_SCOPE = "https://api.securitycenter.microsoft.com/.default"
+    SEVERITY_RANK = {"HIGH": 3, "MEDIUM": 2, "LOW": 1, "INFORMATIONAL": 0}
+
+    def __init__(self):
+        Analyzer.__init__(self)
+        self.tenant_id = self.get_param("config.tenant_id", None, "Missing tenant_id")
+        self.client_id = self.get_param("config.client_id", None, "Missing client_id")
+        self.client_secret = self.get_param("config.client_secret", None, "Missing client_secret")
+        self.service = self.get_param("config.service", None, "Missing service")
+
+    def _get_token(self):
+        body = {
+            "grant_type": "client_credentials",
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+            "scope": self.TOKEN_SCOPE,
+        }
+        try:
+            response = requests.post(self.LOGIN_URL.format(self.tenant_id), data=body, timeout=30)
+        except requests.RequestException as e:
+            self.error("Unable to reach Azure AD login endpoint: {}".format(e))
+
+        if response.status_code != 200:
+            self.error("Azure AD authentication failed (HTTP {}): check tenant_id, client_id and client_secret".format(response.status_code))
+
+        token = response.json().get("access_token")
+        if not token:
+            self.error("Azure AD authentication response did not contain an access token")
+        return token
+
+    def _call_api(self, token, path, params=None):
+        headers = {"Authorization": "Bearer {}".format(token)}
+        try:
+            response = requests.get("{}{}".format(self.API_BASE, path), headers=headers, params=params, timeout=30)
+        except requests.RequestException as e:
+            self.error("Unable to reach Microsoft Defender for Endpoint API: {}".format(e))
+
+        if response.status_code == 404:
+            return None
+        if response.status_code == 403:
+            self.error("Access denied by Microsoft Defender for Endpoint API: check the app's API permissions")
+        if response.status_code >= 400:
+            try:
+                api_error = response.json().get("error", {})
+                detail = "{}: {}".format(api_error.get("code"), api_error.get("message"))
+            except ValueError:
+                detail = response.text
+            self.error("Microsoft Defender for Endpoint API error (HTTP {}): {}".format(response.status_code, detail))
+        return response.json()
+
+    def _max_severity(self, alerts):
+        best = None
+        best_rank = -1
+        for alert in alerts:
+            severity = (alert.get("severity") or "").upper()
+            rank = self.SEVERITY_RANK.get(severity, -1)
+            if rank > best_rank:
+                best_rank = rank
+                best = alert.get("severity")
+        return best
+
+    def _device_lookup(self, token, data, data_type):
+        if data_type == "ip":
+            # lastExternalIpAddress is not a filterable Machine property in the MDE API
+            # (see https://learn.microsoft.com/en-us/defender-endpoint/api/get-machines)
+            odata_filter = "lastIpAddress eq '{}'".format(data)
+        else:
+            odata_filter = "computerDnsName eq '{}'".format(data)
+
+        result = self._call_api(token, "/machines", params={"$filter": odata_filter})
+        machines = result.get("value", []) if result else []
+
+        report = {"found": bool(machines), "machines": []}
+        for machine in machines:
+            alerts_result = self._call_api(token, "/machines/{}/alerts".format(machine.get("id")))
+            machine["alerts"] = alerts_result.get("value", []) if alerts_result else []
+            report["machines"].append(machine)
+
+        return report
+
+    def _hash_reputation(self, token, data, data_type):
+        file_info = self._call_api(token, "/files/{}".format(data))
+        if file_info is None:
+            return {"found": False, "file": {}, "stats": {}, "alerts": [], "maxSeverity": None}
+
+        stats = self._call_api(token, "/files/{}/stats".format(data)) or {}
+        alerts_result = self._call_api(token, "/files/{}/alerts".format(data)) or {"value": []}
+        alerts = alerts_result.get("value", [])
+
+        return {
+            "found": True,
+            "file": file_info,
+            "stats": stats,
+            "alerts": alerts,
+            "maxSeverity": self._max_severity(alerts),
+        }
+
+    def run(self):
+        data = self.get_data()
+        data_type = self.get_param("dataType")
+
+        if self.service == "device_lookup":
+            if data_type not in ["ip", "fqdn"]:
+                return self.notSupported()
+        elif self.service == "hash_reputation":
+            if data_type != "hash":
+                return self.notSupported()
+            if len(data) not in (40, 64):
+                return self.error("MSDefenderForEndpoint only supports SHA1 or SHA256 hashes for file lookups")
+        else:
+            return self.error("Unknown service: {}".format(self.service))
+
+        token = self._get_token()
+
+        if self.service == "device_lookup":
+            result = self._device_lookup(token, data, data_type)
+        else:
+            result = self._hash_reputation(token, data, data_type)
+
+        self.report(result)
+
+    def summary(self, raw):
+        taxonomies = []
+
+        if self.service == "device_lookup":
+            if not raw.get("found"):
+                taxonomies.append(self.build_taxonomy("info", "MDE", "Device", "NotFound"))
+                return {"taxonomies": taxonomies}
+
+            for machine in raw.get("machines", []):
+                risk = (machine.get("riskScore") or "None").upper()
+                if risk == "HIGH":
+                    level = "malicious"
+                elif risk == "MEDIUM":
+                    level = "suspicious"
+                elif risk == "LOW":
+                    level = "safe"
+                else:
+                    level = "info"
+                taxonomies.append(self.build_taxonomy(level, "MDE", "RiskScore", risk.capitalize()))
+
+                alert_count = len(machine.get("alerts", []))
+                if alert_count > 0:
+                    taxonomies.append(self.build_taxonomy("suspicious", "MDE", "Alerts", str(alert_count)))
+
+        elif self.service == "hash_reputation":
+            if not raw.get("found"):
+                taxonomies.append(self.build_taxonomy("info", "MDE", "File", "NotSeen"))
+                return {"taxonomies": taxonomies}
+
+            alerts = raw.get("alerts", [])
+            max_severity = (raw.get("maxSeverity") or "").upper()
+
+            if max_severity == "HIGH":
+                level = "malicious"
+            elif max_severity in ("MEDIUM", "LOW", "INFORMATIONAL"):
+                level = "suspicious"
+            else:
+                org_prevalence = raw.get("stats", {}).get("orgPrevalence", 0)
+                level = "safe" if org_prevalence else "info"
+
+            taxonomies.append(self.build_taxonomy(level, "MDE", "Alerts", str(len(alerts))))
+
+            org_prevalence = raw.get("stats", {}).get("orgPrevalence")
+            if org_prevalence is not None:
+                taxonomies.append(self.build_taxonomy("info", "MDE", "OrgPrevalence", str(org_prevalence)))
+
+        return {"taxonomies": taxonomies}
+
+    def artifacts(self, raw):
+        artifacts = []
+
+        if self.service == "device_lookup":
+            for machine in raw.get("machines", []):
+                ip = machine.get("lastIpAddress")
+                if ip:
+                    artifacts.append(self.build_artifact("ip", ip))
+
+        return artifacts
+
+
+if __name__ == "__main__":
+    MSDefenderForEndpointAnalyzer().run()

--- a/analyzers/MSDefenderForEndpoint/requirements.txt
+++ b/analyzers/MSDefenderForEndpoint/requirements.txt
@@ -1,0 +1,2 @@
+cortexutils>=2.0.0
+requests>=2.20.0

--- a/thehive-templates/MSDefenderForEndpoint_DeviceLookup_1_0/long.html
+++ b/thehive-templates/MSDefenderForEndpoint_DeviceLookup_1_0/long.html
@@ -1,0 +1,77 @@
+<div class="panel panel-info" ng-if="success">
+  <div class="panel-heading">
+    <strong>Microsoft Defender for Endpoint — Device Lookup: {{ (artifact.data) | fang }}</strong>
+  </div>
+  <div class="panel-body">
+    <div ng-if="!content.found" class="alert alert-warning">
+      No device found in Microsoft Defender for Endpoint matching this observable.
+    </div>
+
+    <div ng-repeat="machine in content.machines">
+      <dl class="dl-horizontal">
+        <dt>Device name</dt>
+        <dd>{{ machine.computerDnsName || 'N/A' }}</dd>
+
+        <dt>Risk score</dt>
+        <dd>
+          <span class="label" ng-class="{
+            'label-danger': (machine.riskScore | lowercase) === 'high',
+            'label-warning': (machine.riskScore | lowercase) === 'medium',
+            'label-success': (machine.riskScore | lowercase) === 'low',
+            'label-default': !machine.riskScore || (machine.riskScore | lowercase) === 'none'
+          }">{{ machine.riskScore || 'None' }}</span>
+        </dd>
+
+        <dt>Exposure level</dt>
+        <dd>{{ machine.exposureLevel || 'N/A' }}</dd>
+
+        <dt>Health status</dt>
+        <dd>{{ machine.healthStatus || 'N/A' }}</dd>
+
+        <dt>OS platform</dt>
+        <dd>{{ machine.osPlatform || 'N/A' }}</dd>
+
+        <dt>Last IP address</dt>
+        <dd>{{ machine.lastIpAddress || 'N/A' }}</dd>
+
+        <dt ng-if="machine.alerts.length">Related alerts ({{ machine.alerts.length }})</dt>
+        <dd ng-if="machine.alerts.length">
+          <table class="table table-condensed">
+            <thead>
+              <tr>
+                <th>Title</th>
+                <th>Severity</th>
+                <th>Status</th>
+                <th>Category</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr ng-repeat="alert in machine.alerts">
+                <td>{{ alert.title }}</td>
+                <td>
+                  <span class="label" ng-class="{
+                    'label-danger': (alert.severity | lowercase) === 'high',
+                    'label-warning': (alert.severity | lowercase) === 'medium',
+                    'label-info': (alert.severity | lowercase) === 'low' || (alert.severity | lowercase) === 'informational'
+                  }">{{ alert.severity }}</span>
+                </td>
+                <td>{{ alert.status }}</td>
+                <td>{{ alert.category }}</td>
+              </tr>
+            </tbody>
+          </table>
+        </dd>
+
+        <dt>Portal link</dt>
+        <dd><a href="https://security.microsoft.com/machines/{{ machine.id }}" target="_blank">Open in Microsoft Defender portal</a></dd>
+      </dl>
+      <hr ng-if="!$last">
+    </div>
+  </div>
+</div>
+<div class="panel panel-danger" ng-if="!success">
+  <div class="panel-heading">
+    <strong>{{ (artifact.data) | fang }}</strong>
+  </div>
+  <div class="panel-body">{{ content.errorMessage }}</div>
+</div>

--- a/thehive-templates/MSDefenderForEndpoint_DeviceLookup_1_0/short.html
+++ b/thehive-templates/MSDefenderForEndpoint_DeviceLookup_1_0/short.html
@@ -1,0 +1,3 @@
+<span class="label" ng-repeat="t in content.taxonomies" ng-class="{'info': 'label-info', 'safe': 'label-success', 'suspicious': 'label-warning', 'malicious':'label-danger'}[t.level]">
+    {{t.namespace}}:{{t.predicate}}="{{t.value}}"
+</span>

--- a/thehive-templates/MSDefenderForEndpoint_HashReputation_1_0/long.html
+++ b/thehive-templates/MSDefenderForEndpoint_HashReputation_1_0/long.html
@@ -1,0 +1,74 @@
+<div class="panel panel-info" ng-if="success">
+  <div class="panel-heading">
+    <strong>Microsoft Defender for Endpoint — File Reputation: {{ (artifact.data) | fang }}</strong>
+  </div>
+  <div class="panel-body">
+    <div ng-if="!content.found" class="alert alert-warning">
+      This file hash has not been observed in your organization by Microsoft Defender for Endpoint.
+    </div>
+
+    <dl class="dl-horizontal" ng-if="content.found">
+      <dt>SHA1</dt>
+      <dd>{{ content.file.sha1 || 'N/A' }}</dd>
+
+      <dt>SHA256</dt>
+      <dd>{{ content.file.sha256 || 'N/A' }}</dd>
+
+      <dt>File type</dt>
+      <dd>{{ content.file.fileType || 'N/A' }}</dd>
+
+      <dt>Signer</dt>
+      <dd>{{ content.file.signer || 'N/A' }}</dd>
+
+      <dt>Org prevalence</dt>
+      <dd>{{ content.stats.orgPrevalence !== undefined ? content.stats.orgPrevalence : 'N/A' }}</dd>
+
+      <dt>Global prevalence</dt>
+      <dd>{{ content.file.globalPrevalence !== undefined ? content.file.globalPrevalence : 'N/A' }}</dd>
+
+      <dt>Max alert severity</dt>
+      <dd>
+        <span class="label" ng-class="{
+          'label-danger': (content.maxSeverity | lowercase) === 'high',
+          'label-warning': (content.maxSeverity | lowercase) === 'medium',
+          'label-info': (content.maxSeverity | lowercase) === 'low' || (content.maxSeverity | lowercase) === 'informational',
+          'label-default': !content.maxSeverity
+        }">{{ content.maxSeverity || 'None' }}</span>
+      </dd>
+
+      <dt ng-if="content.alerts.length">Related alerts ({{ content.alerts.length }})</dt>
+      <dd ng-if="content.alerts.length">
+        <table class="table table-condensed">
+          <thead>
+            <tr>
+              <th>Title</th>
+              <th>Severity</th>
+              <th>Status</th>
+              <th>Category</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr ng-repeat="alert in content.alerts">
+              <td>{{ alert.title }}</td>
+              <td>
+                <span class="label" ng-class="{
+                  'label-danger': (alert.severity | lowercase) === 'high',
+                  'label-warning': (alert.severity | lowercase) === 'medium',
+                  'label-info': (alert.severity | lowercase) === 'low' || (alert.severity | lowercase) === 'informational'
+                }">{{ alert.severity }}</span>
+              </td>
+              <td>{{ alert.status }}</td>
+              <td>{{ alert.category }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </dd>
+    </dl>
+  </div>
+</div>
+<div class="panel panel-danger" ng-if="!success">
+  <div class="panel-heading">
+    <strong>{{ (artifact.data) | fang }}</strong>
+  </div>
+  <div class="panel-body">{{ content.errorMessage }}</div>
+</div>

--- a/thehive-templates/MSDefenderForEndpoint_HashReputation_1_0/short.html
+++ b/thehive-templates/MSDefenderForEndpoint_HashReputation_1_0/short.html
@@ -1,0 +1,3 @@
+<span class="label" ng-repeat="t in content.taxonomies" ng-class="{'info': 'label-info', 'safe': 'label-success', 'suspicious': 'label-warning', 'malicious':'label-danger'}[t.level]">
+    {{t.namespace}}:{{t.predicate}}="{{t.value}}"
+</span>


### PR DESCRIPTION
## Summary

New analyzer for Microsoft Defender for Endpoint (MDE), pairing with the
`MSDefenderForEndpoint` responder. Two flavors, one Azure AD app registration:

- **DeviceLookup** (`ip`, `fqdn`): returns risk score, exposure level, health status, OS
  platform, related alerts.
- **HashReputation** (`hash`, SHA1/SHA256 only, MD5 not supported by the MDE files
  API): returns organization prevalence, related alerts.

## Auth

OAuth v2.0 (`oauth2/v2.0/token`), scope pinned to
`https://api.securitycenter.microsoft.com/.default` even though the API host is the
unified `api.security.microsoft.com`  (required by current MS docs, otherwise 403).

## Requirements

Azure AD app registration with `Machine.Read.All`, `Alert.Read.All`, `File.Read.All`
application permissions (admin consent required) (see `README.md`).

## Testing

Tested against a real MDE tenant and TheHive/Cortex local instances.
