### PR TITLE
MSEntraID analyzers - Bug fix & 3 new analyzers (directory roles, sign-ins by IP and risky user)

### DIFF
--- a/analyzers/MSEntraID/MSEntraID.py
+++ b/analyzers/MSEntraID/MSEntraID.py
@@ -6,7 +6,6 @@ import traceback
 from datetime import datetime, timedelta
 from cortexutils.analyzer import Analyzer
 import re
-#import json
 
 
 GUID_RE = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-"
@@ -14,6 +13,27 @@ GUID_RE = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-"
 
 class NoGUIDException(Exception):
     pass
+
+# Built-in Microsoft Entra ID roles considered highly privileged, used to flag
+# directory role assignments that warrant priority attention during an investigation.
+PRIVILEGED_ROLE_NAMES = {
+    "global administrator",
+    "privileged role administrator",
+    "privileged authentication administrator",
+    "security administrator",
+    "user administrator",
+    "application administrator",
+    "cloud application administrator",
+    "conditional access administrator",
+    "authentication administrator",
+    "exchange administrator",
+    "sharepoint administrator",
+    "intune administrator",
+    "compliance administrator",
+    "billing administrator",
+    "hybrid identity administrator",
+    "partner tier2 support",
+}
 
 # Initialize Azure Class
 class MSEntraID(Analyzer):
@@ -243,7 +263,6 @@ class MSEntraID(Analyzer):
                     }
 
             user_info_url = f"{base_url}users/{self.guid}"
-#            user_info_url = f"{base_url}users/{self.user}"
 
             user_response = requests.get(user_info_url, headers=headers, params=params)
 
@@ -509,7 +528,6 @@ class MSEntraID(Analyzer):
                     self.error("No device name supplied")
                 else:
                     self.error("No user UPN supplied")
-            
             if self.data_type == 'mail':
                 self.user = query_value
                 # Resolve UPN to GUID and use exact match
@@ -550,7 +568,221 @@ class MSEntraID(Analyzer):
         except Exception:
             self.error(traceback.format_exc())
 
-    
+    def handle_get_directory_roles(self, headers, base_url):
+        """
+        Retrieves the Microsoft Entra ID directory roles (built-in admin roles) directly
+        assigned to a user, to help prioritize investigations involving privileged accounts.
+
+        Reference: https://learn.microsoft.com/en-us/graph/api/user-list-transitivememberof
+
+        Limitation: only active/direct role assignments are returned. PIM-eligible roles
+        that haven't been activated, and roles granted through a role-assignable group,
+        are not included.
+        """
+        if self.data_type != 'mail':
+            self.error('Incorrect dataType. "mail" expected.')
+
+        try:
+            self.user = self.get_data()
+            if not self.user:
+                self.error("No user supplied")
+            self.guid = self.ensure_user_guid(base_url, headers)
+
+            url = f"{base_url}users/{self.guid}/transitiveMemberOf/microsoft.graph.directoryRole"
+            params = {"$select": "id,displayName,description"}
+
+            roles = []
+            while url:
+                r = requests.get(url, headers=headers, params=params)
+                if r.status_code != 200:
+                    self.error(f"Failed to fetch directory roles for {self.user}: {r.text}")
+                data = r.json()
+                roles.extend(data.get("value", []))
+                url = data.get("@odata.nextLink")
+                params = None
+
+            privileged_roles = [
+                role for role in roles
+                if role.get("displayName", "").strip().lower() in PRIVILEGED_ROLE_NAMES
+            ]
+
+            self.report({
+                "userPrincipalName": self.user,
+                "directoryRoles": roles,
+                "privilegedRoles": privileged_roles,
+            })
+
+        except NoGUIDException as ex:
+            self.report({'message': str(ex)})
+        except Exception:
+            self.error(traceback.format_exc())
+
+    def handle_get_signins_by_ip(self, headers, base_url):
+        """
+        Retrieve sign-in logs across the whole tenant for a given source IP address,
+        within a specified time range. Useful to pivot from a suspicious IP observable
+        to every account it interacted with (e.g. credential stuffing, password spray).
+        """
+        if self.data_type != 'ip':
+            self.error('Incorrect dataType. "ip" expected.')
+
+        try:
+            ip = self.get_data()
+            if not ip:
+                self.error("No IP address supplied")
+
+            filter_time = datetime.utcnow() - timedelta(days=self.time_range)
+            format_time = filter_time.strftime('%Y-%m-%dT00:00:00Z')
+
+            url = f"{base_url}auditLogs/signIns"
+            params = {
+                "$filter": f"ipAddress eq '{ip}' and createdDateTime ge {format_time}",
+                "$top": self.lookup_limit,
+            }
+
+            r = requests.get(url, headers=headers, params=params)
+            if r.status_code != 200:
+                self.error(f"Failure to pull sign-ins for IP {ip}: {r.content}")
+
+            signins_data = r.json().get('value', [])
+
+            signins = []
+            distinct_users = set()
+            failed = 0
+            risky = 0
+
+            for signin in signins_data:
+                upn = signin.get("userPrincipalName", "N/A")
+                distinct_users.add(upn)
+
+                status_info = signin.get("status", {})
+                success = status_info.get("errorCode") == 0
+                if not success:
+                    failed += 1
+
+                risk_level = signin.get("riskLevelDuringSignIn", "none")
+                if risk_level in ["low", "medium", "high"] and success:
+                    risky += 1
+
+                signins.append({
+                    "id": signin.get("id", "N/A"),
+                    "signInTime": signin.get("createdDateTime", "N/A"),
+                    "userPrincipalName": upn,
+                    "userDisplayName": signin.get("userDisplayName", "N/A"),
+                    "appName": signin.get("appDisplayName", "N/A"),
+                    "result": "Success" if success else f"Failure: {status_info.get('failureReason', 'N/A')}",
+                    "riskLevel": risk_level,
+                })
+
+            self.report({
+                "ip": ip,
+                "filterParameters": (
+                    f"Top {self.lookup_limit} signins from the last {self.time_range} days. "
+                    f"Displaying {len(signins)} signins."
+                ),
+                "signIns": signins,
+                "sum_stats": {
+                    "distinctUsers": len(distinct_users),
+                    "failedSignIns": failed,
+                    "riskySignIns": risky,
+                },
+            })
+
+        except Exception:
+            self.error(traceback.format_exc())
+
+    def handle_get_risky_user(self, headers, base_url):
+        """
+        Retrieves Microsoft Entra ID Identity Protection risk information for a user:
+        their current aggregate risk state (riskyUsers) and their risk detection
+        history (riskDetections).
+
+        Reference:
+        https://learn.microsoft.com/en-us/graph/api/riskyuser-get
+        https://learn.microsoft.com/en-us/graph/api/riskdetection-list
+
+        Requires a Microsoft Entra ID P2 license for riskyUsers and P1/P2 for
+        riskDetections. Each is fetched independently and degrades gracefully (with
+        an explanatory message) instead of failing the whole analyzer if the tenant
+        isn't licensed, or the app is missing one of the two permissions.
+        """
+        if self.data_type != 'mail':
+            self.error('Incorrect dataType. "mail" expected.')
+
+        try:
+            self.user = self.get_data()
+            if not self.user:
+                self.error("No user supplied")
+            self.guid = self.ensure_user_guid(base_url, headers)
+
+            result = {
+                "userPrincipalName": self.user,
+                "riskyUser": None,
+                "riskyUserError": None,
+                "riskDetections": [],
+                "riskDetectionsError": None,
+            }
+
+            # Current aggregate risk state. riskyUser.id is the user's own object ID,
+            # so it can be fetched directly without a $filter.
+            risky_user_resp = requests.get(
+                f"{base_url}identityProtection/riskyUsers/{self.guid}", headers=headers
+            )
+            if risky_user_resp.status_code in (200, 404):
+                risky_user = risky_user_resp.json() if risky_user_resp.status_code == 200 else {}
+                result["riskyUser"] = {
+                    "riskLevel": risky_user.get("riskLevel", "none"),
+                    "riskState": risky_user.get("riskState", "none"),
+                    "riskDetail": risky_user.get("riskDetail", "none"),
+                    "riskLastUpdatedDateTime": risky_user.get("riskLastUpdatedDateTime", "N/A"),
+                    "isProcessing": risky_user.get("isProcessing", False),
+                }
+            else:
+                result["riskyUserError"] = (
+                    f"Failed to retrieve current risk state (HTTP {risky_user_resp.status_code}). "
+                    f"Requires Entra ID P2 and the IdentityRiskyUser.Read.All permission. "
+                    f"Details: {risky_user_resp.text}"
+                )
+
+            # Risk detection history
+            filter_time = (datetime.utcnow() - timedelta(days=self.time_range)).strftime('%Y-%m-%dT%H:%M:%SZ')
+            url = f"{base_url}identityProtection/riskDetections"
+            params = {
+                "$filter": f"userId eq '{self.guid}' and detectedDateTime ge {filter_time}",
+                "$top": min(self.lookup_limit, 500),
+            }
+
+            detections_resp = requests.get(url, headers=headers, params=params)
+            if detections_resp.status_code == 200:
+                detections = detections_resp.json().get("value", [])
+
+                result["riskDetections"] = [
+                    {
+                        "riskEventType": d.get("riskEventType", "N/A"),
+                        "riskLevel": d.get("riskLevel", "N/A"),
+                        "riskState": d.get("riskState", "N/A"),
+                        "riskDetail": d.get("riskDetail", "N/A"),
+                        "activity": d.get("activity", "N/A"),
+                        "ipAddress": d.get("ipAddress", "N/A"),
+                        "location": d.get("location", {}),
+                        "detectedDateTime": d.get("detectedDateTime", "N/A"),
+                    }
+                    for d in detections
+                ]
+            else:
+                result["riskDetectionsError"] = (
+                    f"Failed to retrieve risk detection history (HTTP {detections_resp.status_code}). "
+                    f"Requires Entra ID P1/P2 and the IdentityRiskEvent.Read.All permission. "
+                    f"Details: {detections_resp.text}"
+                )
+
+            self.report(result)
+
+        except NoGUIDException as ex:
+            self.report({'message': str(ex)})
+        except Exception:
+            self.error(traceback.format_exc())
+
     def run(self):
         Analyzer.run(self)
 
@@ -570,6 +802,12 @@ class MSEntraID(Analyzer):
             self.handle_get_directoryAuditLogs(headers, base_url)
         elif self.service == "getManagedDevicesInfo":
             self.handle_get_devices(headers, base_url)
+        elif self.service == "getDirectoryRoles":
+            self.handle_get_directory_roles(headers, base_url)
+        elif self.service == "getSignInsByIP":
+            self.handle_get_signins_by_ip(headers, base_url)
+        elif self.service == "getRiskyUser":
+            self.handle_get_risky_user(headers, base_url)
         else:
             self.error({"message": "Unidentified service"})
 
@@ -630,17 +868,49 @@ class MSEntraID(Analyzer):
             # Get the count of devices returned.
             count = len(raw.get("devices", []))
             taxonomies.append(self.build_taxonomy('info', 'MSEntraIDManagedDevices', 'count', count))
+        elif self.service == "getDirectoryRoles":
+            privileged = raw.get("privilegedRoles", [])
+            total = len(raw.get("directoryRoles", []))
+            if privileged:
+                names = ", ".join(r.get("displayName", "Unknown") for r in privileged)
+                taxonomies.append(self.build_taxonomy('suspicious', 'MSEntraIDRoles', 'Privileged', names))
+            elif total:
+                taxonomies.append(self.build_taxonomy('info', 'MSEntraIDRoles', 'Count', total))
+            else:
+                taxonomies.append(self.build_taxonomy('safe', 'MSEntraIDRoles', 'Count', 0))
+        elif self.service == "getSignInsByIP":
+            stats = raw.get("sum_stats", {})
+            taxonomies.append(self.build_taxonomy('info', 'MSEntraIDSigninsByIP', 'DistinctUsers', stats.get("distinctUsers", 0)))
+            if stats.get("riskySignIns", 0) != 0:
+                taxonomies.append(self.build_taxonomy('suspicious', 'MSEntraIDSigninsByIP', 'Risky', stats["riskySignIns"]))
+            if stats.get("distinctUsers", 0) > 1 and stats.get("failedSignIns", 0) > 0:
+                taxonomies.append(self.build_taxonomy('suspicious', 'MSEntraIDSigninsByIP', 'FailedAcrossUsers', stats["failedSignIns"]))
+        elif self.service == "getRiskyUser":
+            if raw.get("riskyUserError"):
+                taxonomies.append(self.build_taxonomy('info', 'MSEntraIDRisk', 'Status', 'Unavailable'))
+            else:
+                risky_user = raw.get("riskyUser") or {}
+                risk_state = risky_user.get("riskState", "none")
+                risk_level = risky_user.get("riskLevel", "none")
+
+                if risk_state == "atRisk" and risk_level == "high":
+                    level = "malicious"
+                elif risk_state == "atRisk":
+                    level = "suspicious"
+                elif risk_state in ("remediated", "dismissed", "confirmedSafe"):
+                    level = "safe"
+                else:
+                    level = "info"
+                taxonomies.append(self.build_taxonomy(level, 'MSEntraIDRisk', 'State', risk_state))
+
+            detections = len(raw.get("riskDetections", []))
+            if detections:
+                taxonomies.append(self.build_taxonomy('suspicious', 'MSEntraIDRisk', 'Detections', detections))
         return {'taxonomies': taxonomies}
 
     def artifacts(self, raw):
         artifacts = []
         raw_str = str(raw)
-
-        # Attempt to parse the raw data as JSON to later capture structured fields
-        #try:
-        #    data = json.loads(raw_str)
-        #except Exception:
-        #    data = None
 
         extracted_data = self.get_data()  # Store observed value
         observed_type = self.data_type    # Store expected data type

--- a/analyzers/MSEntraID/MSEntraID_GetDirectoryRoles.json
+++ b/analyzers/MSEntraID/MSEntraID_GetDirectoryRoles.json
@@ -1,0 +1,43 @@
+{
+    "name": "MSEntraID_GetDirectoryRoles",
+    "version": "1.0",
+    "author": "3lina, StrangeBee",
+    "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
+    "license": "AGPL-V3",
+    "description": "List the Microsoft Entra ID directory roles (built-in admin roles) directly assigned to a user, to help prioritize investigations involving privileged accounts.",
+    "dataTypeList": [
+        "mail"
+    ],
+    "command": "MSEntraID/MSEntraID.py",
+    "baseConfig": "MSEntraID",
+    "config": {
+        "service": "getDirectoryRoles"
+    },
+    "configurationItems": [
+        {
+            "name": "tenant_id",
+            "description": "Microsoft Entra ID Tenant ID",
+            "type": "string",
+            "multi": false,
+            "required": true
+        },
+        {
+            "name": "client_id",
+            "description": "Client ID/Application ID of Microsoft Entra ID Registered App",
+            "type": "string",
+            "multi": false,
+            "required": true
+        },
+        {
+            "name": "client_secret",
+            "description": "Secret for Microsoft Entra ID Registered Application",
+            "type": "string",
+            "multi": false,
+            "required": true
+        }
+    ],
+    "registration_required": true,
+    "subscription_required": true,
+    "free_subscription": false,
+    "service_homepage": "https://www.microsoft.com/security/business/identity-access/microsoft-entra-id"
+}

--- a/analyzers/MSEntraID/MSEntraID_GetRiskyUser.json
+++ b/analyzers/MSEntraID/MSEntraID_GetRiskyUser.json
@@ -1,0 +1,59 @@
+{
+    "name": "MSEntraID_GetRiskyUser",
+    "version": "1.0",
+    "author": "StrangeBee",
+    "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
+    "license": "AGPL-V3",
+    "description": "Retrieve Microsoft Entra ID Identity Protection risk information for a user: current risk state (riskyUsers) and risk detection history (riskDetections). Requires Entra ID P1/P2.",
+    "dataTypeList": [
+        "mail"
+    ],
+    "command": "MSEntraID/MSEntraID.py",
+    "baseConfig": "MSEntraID",
+    "config": {
+        "service": "getRiskyUser"
+    },
+    "configurationItems": [
+        {
+            "name": "tenant_id",
+            "description": "Microsoft Entra ID Tenant ID",
+            "type": "string",
+            "multi": false,
+            "required": true
+        },
+        {
+            "name": "client_id",
+            "description": "Client ID/Application ID of Microsoft Entra ID Registered App",
+            "type": "string",
+            "multi": false,
+            "required": true
+        },
+        {
+            "name": "client_secret",
+            "description": "Secret for Microsoft Entra ID Registered Application",
+            "type": "string",
+            "multi": false,
+            "required": true
+        },
+        {
+            "name": "lookup_range",
+            "description": "Check for risk detections in the last X days. Should be between 1 and 90 days.",
+            "type": "number",
+            "multi": false,
+            "required": false,
+            "defaultValue": 30
+        },
+        {
+            "name": "lookup_limit",
+            "description": "Display no more than this many risk detections.",
+            "type": "number",
+            "multi": false,
+            "required": false,
+            "defaultValue": 20
+        }
+    ],
+    "registration_required": true,
+    "subscription_required": true,
+    "free_subscription": false,
+    "service_homepage": "https://www.microsoft.com/security/business/identity-access/microsoft-entra-id"
+}

--- a/analyzers/MSEntraID/MSEntraID_GetSignInsByIP.json
+++ b/analyzers/MSEntraID/MSEntraID_GetSignInsByIP.json
@@ -1,0 +1,59 @@
+{
+    "name": "MSEntraID_GetSignInsByIP",
+    "version": "1.0",
+    "author": "3lina, StrangeBee",
+    "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
+    "license": "AGPL-V3",
+    "description": "Pull all Microsoft Entra ID sign ins across the tenant that originated from a given IP address, within the specified amount of time.",
+    "dataTypeList": [
+        "ip"
+    ],
+    "command": "MSEntraID/MSEntraID.py",
+    "baseConfig": "MSEntraID",
+    "config": {
+        "service": "getSignInsByIP"
+    },
+    "configurationItems": [
+        {
+            "name": "tenant_id",
+            "description": "Microsoft Entra ID Tenant ID",
+            "type": "string",
+            "multi": false,
+            "required": true
+        },
+        {
+            "name": "client_id",
+            "description": "Client ID/Application ID of Microsoft Entra ID Registered App",
+            "type": "string",
+            "multi": false,
+            "required": true
+        },
+        {
+            "name": "client_secret",
+            "description": "Secret for Microsoft Entra ID Registered Application",
+            "type": "string",
+            "multi": false,
+            "required": true
+        },
+        {
+            "name": "lookup_range",
+            "description": "Check for sign ins in the last X days. Should be between 1 and 31 days.",
+            "type": "number",
+            "multi": false,
+            "required": false,
+            "defaultValue": 7
+        },
+        {
+            "name": "lookup_limit",
+            "description": "Display no more than this many sign ins.",
+            "type": "number",
+            "multi": false,
+            "required": false,
+            "defaultValue": 50
+        }
+    ],
+    "registration_required": true,
+    "subscription_required": true,
+    "free_subscription": false,
+    "service_homepage": "https://www.microsoft.com/security/business/identity-access/microsoft-entra-id"
+}

--- a/analyzers/MSEntraID/README.md
+++ b/analyzers/MSEntraID/README.md
@@ -16,6 +16,9 @@ This repository provides a set of **Cortex** analyzers to enrich your investigat
         - [getUserInfo](#getuserinfo)  
         - [getDirectoryAuditLogs](#getdirectoryauditlogs)  
         - [getManagedDevicesInfo](#getmanageddevicesinfo-requires-ms-intune)  
+        - [getDirectoryRoles](#getdirectoryroles)  
+        - [getSignInsByIP](#getsigninsbyip)  
+        - [getRiskyUser (requires Entra ID P1/P2)](#getriskyuser-requires-entra-id-p1p2)  
 5. [Customization](#customization)  
 6. [General Notes on Permissions](#general-notes-on-permissions)  
 7. [References](#references)
@@ -26,10 +29,12 @@ This repository provides a set of **Cortex** analyzers to enrich your investigat
 
 These analyzers provide useful context for Incident Response teams, such as:
 
-- **Sign-in logs** (location, risk, IP, etc.)
+- **Sign-in logs** (location, risk, IP, etc.), by user or by source IP address
 - **User profile details** (manager, licenses, groups, MFA methods)
 - **Directory audit logs** (object changes in Azure AD)
 - **Intune-managed devices** (compliance, OS, last sync)
+- **Directory role assignments** (is this user a privileged/admin account?)
+- **Identity Protection risk signals** (current risk state and risk detection history)
 
 ---
 
@@ -40,7 +45,7 @@ All analyzers share these config fields:
 - **`client_id`**: Application (client) ID of your Azure AD app registration  
 - **`client_secret`**: Client Secret generated for that app  
 - **`tenant_id`**: Azure AD Tenant ID  
-- **`service`**: Which analyzer action to run, hardcoded (such as `getSignIns`, `getUserInfo`, `getDirectoryAuditLogs`, `getManagedDevicesInfo`)  
+- **`service`**: Which analyzer action to run, hardcoded (such as `getSignIns`, `getUserInfo`, `getDirectoryAuditLogs`, `getManagedDevicesInfo`, `getDirectoryRoles`, `getSignInsByIP`, `getRiskyUser`)  
 
 Additional parameters (such as **lookup_range**, **lookup_limit**, **state**, **country**) appear in certain analyzers. They allow you to define:
 
@@ -75,6 +80,8 @@ Additional parameters (such as **lookup_range**, **lookup_limit**, **state**, **
    - **`AuditLog.Read.All`**  
    - **`DeviceManagementManagedDevices.Read.All`** (Intune analyzers)
    - **`UserAuthenticationMethod.Read.All`** (if fetching MFA)  
+   - **`IdentityRiskyUser.Read.All`** (getRiskyUser — current risk state, requires Entra ID P2)
+   - **`IdentityRiskEvent.Read.All`** (getRiskyUser — risk detection history, requires Entra ID P1/P2)  
 9. For each **Application** permission, use a **Global Administrator** account to **Grant admin consent**.  
 10. Copy your **Tenant ID**, **Application (Client) ID**, and the **Client Secret** into the analyzer configuration in Cortex.
 
@@ -125,6 +132,7 @@ Enriches context around a user with **user profile details** from Microsoft Entr
 **Required Permissions**  
 - **`Directory.Read.All`** or **`User.Read.All`** for user properties & group membership.  
 - **`UserAuthenticationMethod.Read.All`** if retrieving MFA methods.
+- **`AuditLog.Read.All`** is required if you add `signInActivity` to `params_list` to populate `lastSignInDateTime` (not in the default list). ⚠️ Selecting it without this permission makes the *entire* `/users` request fail with a 403, not just that field — only add it if you're sure the permission is granted.
 
 **Sample Usage**
 
@@ -168,6 +176,73 @@ Returns **Intune-managed devices** for a given user’s principal name or hostna
 - Run on TheHive’s observable of type `mail` or `hostname`
 - Analyzer returns a list of Intune devices assigned to that user.
 
+### getDirectoryRoles
+
+**Purpose**  
+Lists the Microsoft Entra ID **directory roles** (built-in admin roles, such as Global Administrator, User Administrator...) directly assigned to a user, to help prioritize investigations involving privileged accounts.
+
+**Key Points**  
+- **Graph Endpoint**  
+- [`GET /users/{id}/transitiveMemberOf/microsoft.graph.directoryRole`](https://learn.microsoft.com/en-us/graph/api/user-list-transitivememberof?view=graph-rest-1.0)  
+- Flags a curated list of highly-privileged built-in role names (Global Administrator, Privileged Role Administrator, Security Administrator, etc.) as `suspicious` in the taxonomy.
+- **Limitation**: only active/direct role assignments are returned. PIM-eligible roles that haven't been activated, and roles granted through a role-assignable group, aren't included.
+
+**Required Permissions**  
+- **`Directory.Read.All`** (same permission already used by `getUserInfo`, no extra consent needed)
+
+**Sample Usage**
+
+- Run on TheHive’s observable of type `mail`
+- Analyzer returns every directory role assigned to that user, and flags privileged ones.
+
+### getSignInsByIP
+
+**Purpose**  
+Pivots from a suspicious **IP address** observable to every Entra ID account that signed in from it, within the specified time range. Useful for spotting credential stuffing / password spray patterns (many distinct users, many failures, from the same IP).
+
+**Key Points**  
+- **Graph Endpoint**  
+- [`GET /auditLogs/signIns`](https://learn.microsoft.com/en-us/graph/api/signin-list?view=graph-rest-1.0)  
+- Filters sign-ins tenant-wide by `ipAddress eq 'x.x.x.x'` and time range.
+
+**Required Permissions**  
+- **`AuditLog.Read.All`** (Application permission, same as `getSignIns`)
+
+**Example Configuration**
+
+- **lookup_range** = 7 (past 7 days)  
+- **lookup_limit** = 50
+
+**Sample Usage**
+
+- Run on TheHive’s observable of type `ip`
+- Analyzer returns every sign-in from that IP in the last 7 days, the number of distinct accounts involved, and flags risky/failed sign-ins.
+
+### getRiskyUser (requires Entra ID P1/P2)
+
+**Purpose**  
+Retrieves Microsoft Entra ID **Identity Protection** risk information for a user: their current aggregate risk state, and their risk detection history (impossible travel, leaked credentials, anonymous IP, etc.).
+
+**Key Points**  
+- **Graph Endpoints**  
+- [`GET /identityProtection/riskyUsers/{id}`](https://learn.microsoft.com/en-us/graph/api/riskyuser-get?view=graph-rest-1.0) current risk state. Requires **Entra ID P2**.
+- [`GET /identityProtection/riskDetections`](https://learn.microsoft.com/en-us/graph/api/riskdetection-list?view=graph-rest-1.0) risk detection history, filtered by `userId` and time range. Requires **Entra ID P1 or P2**.
+- The two calls are independent: if the tenant/app isn't entitled or permissioned for one of them, that part of the report explains why (`riskyUserError` / `riskDetectionsError`) instead of failing the whole analyzer.
+
+**Required Permissions**  
+- **`IdentityRiskyUser.Read.All`** (Application permission)  
+- **`IdentityRiskEvent.Read.All`** (Application permission)
+
+**Example Configuration**
+
+- **lookup_range** = 30 (past 30 days of risk detections)  
+- **lookup_limit** = 20
+
+**Sample Usage**
+
+- Run on TheHive’s observable of type `mail`
+- Analyzer returns the user's current risk level/state and their recent risk detection history.
+
 ---
 
 ## Customization
@@ -190,11 +265,12 @@ To do this, modify **`long.html`** for the analyzer (Sign In). For example, use 
     - Ensure you **Grant admin consent** for the required permissions in Azure AD.
 
 - **Minimal Scopes**  
-    - If you want all analyzers to function, add each relevant scope (such as `AuditLog.Read.All`, `Directory.Read.All`, `DeviceManagementManagedDevices.Read.All`, `UserAuthenticationMethod.Read.All`) to the same app registration.  
+    - If you want all analyzers to function, add each relevant scope (such as `AuditLog.Read.All`, `Directory.Read.All`, `DeviceManagementManagedDevices.Read.All`, `UserAuthenticationMethod.Read.All`, `IdentityRiskyUser.Read.All`, `IdentityRiskEvent.Read.All`) to the same app registration.  
     - Alternatively, create separate app registrations to follow least-privilege principles.
 
 - **Licensing**  
-    - Some features (such as Identity Protection, advanced audit logs) require Azure AD Premium licensing.
+    - `getRiskyUser` requires **Entra ID P2** (riskyUsers) and **Entra ID P1 or P2** (riskDetections). Without the right license, Microsoft Graph returns an authorization error rather than an empty result, the analyzer reports this explicitly instead of failing outright.
+    - Other features (such as advanced audit log retention) may also require Azure AD Premium licensing depending on your tenant configuration.
 
 ---
 
@@ -205,4 +281,7 @@ To do this, modify **`long.html`** for the analyzer (Sign In). For example, use 
 - [Microsoft Graph Query Parameters](https://learn.microsoft.com/en-us/graph/query-parameters?view=graph-rest-1.0)  
 - [Sign In Logs (auditLogs/signIns)](https://learn.microsoft.com/en-us/graph/api/signin-list?view=graph-rest-1.0)  
 - [Directory Audits (auditLogs/directoryAudits)](https://learn.microsoft.com/en-us/graph/api/directoryaudit-list?view=graph-rest-1.0)  
-- [Managed Devices (deviceManagement/managedDevices)](https://learn.microsoft.com/en-us/graph/api/intune-devices-manageddevice-list?view=graph-rest-1.0)
+- [Managed Devices (deviceManagement/managedDevices)](https://learn.microsoft.com/en-us/graph/api/intune-devices-manageddevice-list?view=graph-rest-1.0)  
+- [Directory Roles (transitiveMemberOf)](https://learn.microsoft.com/en-us/graph/api/user-list-transitivememberof?view=graph-rest-1.0)  
+- [Risky Users (identityProtection/riskyUsers)](https://learn.microsoft.com/en-us/graph/api/riskyuser-get?view=graph-rest-1.0)  
+- [Risk Detections (identityProtection/riskDetections)](https://learn.microsoft.com/en-us/graph/api/riskdetection-list?view=graph-rest-1.0)

--- a/thehive-templates/MSEntraID_GetDirectoryRoles_1_0/long.html
+++ b/thehive-templates/MSEntraID_GetDirectoryRoles_1_0/long.html
@@ -1,0 +1,91 @@
+<!-- Success -->
+<div class="panel panel-danger" ng-if="success">
+    <div class="panel-body">
+        <div>
+            <!-- Queried User -->
+            <div class="panel">
+                <div class="panel-heading">
+                    <i class="fa fa-envelope"></i> Queried User
+                </div>
+                <div>
+                    <table class="table">
+                        <tr>
+                            <td><strong>User Principal Name</strong></td>
+                            <td>{{ content.userPrincipalName || 'N/A' }}</td>
+                        </tr>
+                    </table>
+                </div>
+            </div>
+
+            <!-- No Roles Assigned -->
+            <div class="panel panel-success" ng-if="content.directoryRoles.length === 0">
+                <div class="panel-heading">
+                    <i class="fa fa-info-circle"></i> No Directory Roles Assigned
+                </div>
+                <div class="panel-body">
+                    <p>This user has no built-in Entra ID directory role assigned directly.</p>
+                </div>
+            </div>
+
+            <!-- Privileged Roles Warning -->
+            <div class="panel panel-warning" ng-if="content.privilegedRoles.length > 0">
+                <div class="panel-heading">
+                    <i class="fa fa-exclamation-triangle"></i> Privileged Role(s) Detected
+                </div>
+                <div>
+                    <table class="table">
+                        <tr>
+                            <th>Role Name</th>
+                            <th>Description</th>
+                        </tr>
+                        <tr ng-repeat="role in content.privilegedRoles">
+                            <td><span class="label label-danger">{{ role.displayName || 'N/A' }}</span></td>
+                            <td>{{ role.description || 'N/A' }}</td>
+                        </tr>
+                    </table>
+                </div>
+            </div>
+
+            <!-- All Directory Roles -->
+            <div class="panel" ng-if="content.directoryRoles.length > 0">
+                <div class="panel-heading">
+                    <i class="fa fa-user-shield"></i> All Assigned Directory Roles
+                </div>
+                <div>
+                    <table class="table table-striped">
+                        <tr>
+                            <th>Role Name</th>
+                            <th>Description</th>
+                            <th>Role ID</th>
+                        </tr>
+                        <tr ng-repeat="role in content.directoryRoles">
+                            <td>{{ role.displayName || 'N/A' }}</td>
+                            <td>{{ role.description || 'N/A' }}</td>
+                            <td title="{{ role.id }}">{{ role.id | limitTo: 8 }}</td>
+                        </tr>
+                    </table>
+                </div>
+            </div>
+
+            <!-- Not a GUID match -->
+            <div class="panel panel-warning" ng-if="content.message">
+                <div class="panel-body">
+                    <p><i class="fa fa-warning"></i> {{ content.message }}</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- General error -->
+<div class="panel panel-danger" ng-if="!success">
+    <div class="panel-heading">
+        <strong>{{(artifact.data || artifact.attachment.name) | fang}}</strong>
+    </div>
+    <div class="panel-body">
+        <dl class="dl-horizontal" ng-if="content.errorMessage">
+            <dt><i class="fa fa-warning"></i> getDirectoryRoles: </dt>
+            <dd class="wrap">{{content.errorMessage}}</dd>
+        </dl>
+    </div>
+</div>

--- a/thehive-templates/MSEntraID_GetRiskyUser_1_0/long.html
+++ b/thehive-templates/MSEntraID_GetRiskyUser_1_0/long.html
@@ -1,0 +1,155 @@
+<!-- Success -->
+<div class="panel panel-danger" ng-if="success">
+    <div class="panel-body">
+        <div>
+            <!-- Queried User -->
+            <div class="panel">
+                <div class="panel-heading">
+                    <i class="fa fa-envelope"></i> Queried User
+                </div>
+                <div>
+                    <table class="table">
+                        <tr>
+                            <td><strong>User Principal Name</strong></td>
+                            <td>{{ content.userPrincipalName || 'N/A' }}</td>
+                        </tr>
+                    </table>
+                </div>
+            </div>
+
+            <!-- Current Risk State: unavailable -->
+            <div class="panel panel-warning" ng-if="content.riskyUserError">
+                <div class="panel-heading">
+                    <i class="fa fa-exclamation-triangle"></i> Current Risk State Unavailable
+                </div>
+                <div class="panel-body">
+                    <p>{{ content.riskyUserError }}</p>
+                </div>
+            </div>
+
+            <!-- Current Risk State -->
+            <div class="panel" ng-if="content.riskyUser">
+                <div class="panel-heading">
+                    <i class="fa fa-user-shield"></i> Current Risk State (Identity Protection)
+                </div>
+                <div>
+                    <table class="table">
+                        <tr>
+                            <td><strong>Risk State</strong></td>
+                            <td>
+                                <span class="label" ng-class="{
+                                    'label-danger': content.riskyUser.riskState === 'atRisk' || content.riskyUser.riskState === 'confirmedCompromised',
+                                    'label-success': content.riskyUser.riskState === 'remediated' || content.riskyUser.riskState === 'dismissed' || content.riskyUser.riskState === 'confirmedSafe',
+                                    'label-default': content.riskyUser.riskState === 'none'
+                                }">
+                                    {{ content.riskyUser.riskState }}
+                                </span>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><strong>Risk Level</strong></td>
+                            <td>
+                                <span class="label" ng-class="{
+                                    'label-danger': content.riskyUser.riskLevel === 'high',
+                                    'label-warning': content.riskyUser.riskLevel === 'medium' || content.riskyUser.riskLevel === 'low',
+                                    'label-default': content.riskyUser.riskLevel === 'none' || content.riskyUser.riskLevel === 'hidden'
+                                }">
+                                    {{ content.riskyUser.riskLevel }}
+                                </span>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td><strong>Risk Detail</strong></td>
+                            <td>{{ content.riskyUser.riskDetail || 'N/A' }}</td>
+                        </tr>
+                        <tr>
+                            <td><strong>Last Updated</strong></td>
+                            <td>{{ content.riskyUser.riskLastUpdatedDateTime || 'N/A' }}</td>
+                        </tr>
+                        <tr>
+                            <td><strong>Processing</strong></td>
+                            <td>{{ content.riskyUser.isProcessing ? 'Yes' : 'No' }}</td>
+                        </tr>
+                    </table>
+                </div>
+            </div>
+
+            <!-- Risk Detections: unavailable -->
+            <div class="panel panel-warning" ng-if="content.riskDetectionsError">
+                <div class="panel-heading">
+                    <i class="fa fa-exclamation-triangle"></i> Risk Detection History Unavailable
+                </div>
+                <div class="panel-body">
+                    <p>{{ content.riskDetectionsError }}</p>
+                </div>
+            </div>
+
+            <!-- No Risk Detections -->
+            <div class="panel panel-success" ng-if="!content.riskDetectionsError && content.riskDetections.length === 0">
+                <div class="panel-heading">
+                    <i class="fa fa-info-circle"></i> No Risk Detections
+                </div>
+                <div class="panel-body">
+                    <p>No risk detection events found for this user in the selected time range.</p>
+                </div>
+            </div>
+
+            <!-- Risk Detections -->
+            <div class="panel" ng-if="content.riskDetections.length > 0">
+                <div class="panel-heading">
+                    <i class="fa fa-history"></i> Risk Detection History
+                </div>
+                <div>
+                    <table class="table table-striped">
+                        <tr>
+                            <th>Detected</th>
+                            <th>Event Type</th>
+                            <th>Level</th>
+                            <th>State</th>
+                            <th>Activity</th>
+                            <th>IP</th>
+                            <th>Location</th>
+                        </tr>
+                        <tr ng-repeat="d in content.riskDetections">
+                            <td>{{ d.detectedDateTime || 'N/A' }}</td>
+                            <td>{{ d.riskEventType || 'N/A' }}</td>
+                            <td>
+                                <span class="label" ng-class="{
+                                    'label-danger': d.riskLevel === 'high',
+                                    'label-warning': d.riskLevel === 'medium' || d.riskLevel === 'low',
+                                    'label-default': d.riskLevel === 'none' || d.riskLevel === 'hidden'
+                                }">
+                                    {{ d.riskLevel }}
+                                </span>
+                            </td>
+                            <td>{{ d.riskState || 'N/A' }}</td>
+                            <td>{{ d.activity || 'N/A' }}</td>
+                            <td>{{ d.ipAddress || 'N/A' }}</td>
+                            <td>{{ d.location.city }}, {{ d.location.state }}, {{ d.location.countryOrRegion }}</td>
+                        </tr>
+                    </table>
+                </div>
+            </div>
+
+            <!-- Not a GUID match -->
+            <div class="panel panel-warning" ng-if="content.message">
+                <div class="panel-body">
+                    <p><i class="fa fa-warning"></i> {{ content.message }}</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- General error -->
+<div class="panel panel-danger" ng-if="!success">
+    <div class="panel-heading">
+        <strong>{{(artifact.data || artifact.attachment.name) | fang}}</strong>
+    </div>
+    <div class="panel-body">
+        <dl class="dl-horizontal" ng-if="content.errorMessage">
+            <dt><i class="fa fa-warning"></i> getRiskyUser: </dt>
+            <dd class="wrap">{{content.errorMessage}}</dd>
+        </dl>
+    </div>
+</div>

--- a/thehive-templates/MSEntraID_GetSignInsByIP_1_0/long.html
+++ b/thehive-templates/MSEntraID_GetSignInsByIP_1_0/long.html
@@ -1,0 +1,81 @@
+<!-- When no sign-ins found -->
+<div class="panel panel-success" ng-if="success && content.signIns.length == 0">
+    <div class="panel-heading">
+        <i class="fa fa-info-circle"></i> Microsoft Entra ID Sign Ins by IP
+    </div>
+    <div class="panel-body">
+        <p><strong>IP:</strong> {{content.ip}}</p>
+        <p><i class="fa fa-filter"></i> Analyzers searched for: {{content.filterParameters}}</p>
+    </div>
+</div>
+
+<!-- When sign-ins are available -->
+<div class="panel panel-primary" ng-if="success && content.signIns.length > 0">
+    <div class="panel-heading">
+        <i class="fa fa-sign-in-alt"></i> Microsoft Entra ID Sign Ins from {{content.ip}}
+    </div>
+    <div class="panel-body">
+        <!-- Summary stats -->
+        <table class="table">
+            <tr>
+                <td><strong>Distinct Users</strong></td>
+                <td>
+                    <span class="label" ng-class="{
+                        'label-danger': content.sum_stats.distinctUsers > 1,
+                        'label-success': content.sum_stats.distinctUsers <= 1
+                    }">
+                        {{ content.sum_stats.distinctUsers }}
+                    </span>
+                </td>
+                <td><strong>Failed Sign-Ins</strong></td>
+                <td>{{ content.sum_stats.failedSignIns }}</td>
+                <td><strong>Risky Sign-Ins</strong></td>
+                <td>{{ content.sum_stats.riskySignIns }}</td>
+            </tr>
+        </table>
+
+        <table class="table table-striped">
+            <thead>
+                <tr>
+                    <th><i class="fa fa-id-badge"></i> SignIn ID</th>
+                    <th><i class="fa fa-clock"></i> Time</th>
+                    <th><i class="fa fa-user"></i> User</th>
+                    <th><i class="fa fa-info"></i> Status</th>
+                    <th><i class="fa fa-th"></i> App Name</th>
+                    <th><i class="fa fa-exclamation-triangle"></i> Risk</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr ng-repeat="r in content.signIns">
+                    <td title="{{r.id}}">{{r.id | limitTo: 8}}</td>
+                    <td>{{r.signInTime}}</td>
+                    <td title="{{r.userPrincipalName}}">{{r.userDisplayName || r.userPrincipalName}}</td>
+                    <td title="{{r.result}}">{{r.result | limitTo: 20}}</td>
+                    <td>{{r.appName}}</td>
+                    <td>
+                        <span class="label" ng-class="{
+                            'label-danger': r.riskLevel === 'high',
+                            'label-warning': r.riskLevel === 'medium' || r.riskLevel === 'low',
+                            'label-default': r.riskLevel === 'none' || r.riskLevel === 'hidden'
+                        }">
+                            {{ r.riskLevel }}
+                        </span>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<!-- General error -->
+<div class="panel panel-danger" ng-if="!success">
+    <div class="panel-heading">
+        <i class="fa fa-warning"></i> <strong>{{(artifact.data || artifact.attachment.name) | fang}}</strong>
+    </div>
+    <div class="panel-body">
+        <dl class="dl-horizontal" ng-if="content.errorMessage">
+            <dt><i class="fa fa-warning"></i> MSEntraID_GetSignInsByIP:</dt>
+            <dd class="wrap">{{content.errorMessage}}</dd>
+        </dl>
+    </div>
+</div>

--- a/thehive-templates/MSEntraID_GetUserInfo_1_0/long.html
+++ b/thehive-templates/MSEntraID_GetUserInfo_1_0/long.html
@@ -120,12 +120,15 @@
                 <div>
                     <table class="table">
                         <tr>
-                            <th>Service Plan ID</th>
-                            <th>Plan Name</th>
+                            <th>License (SKU)</th>
+                            <th>Service Plans</th>
                         </tr>
                         <tr ng-repeat="license in content.assignedLicenses">
-                            <td>{{ license.skuPartNumber }}</td>
-                            <td>{{ license.servicePlanName || 'N/A' }}</td>
+                            <td>{{ license.skuPartNumber || 'N/A' }}</td>
+                            <td ng-if="!license.servicePlans.length">N/A</td>
+                            <td ng-if="license.servicePlans.length">
+                                <span ng-repeat="sp in license.servicePlans">{{ sp.servicePlanName }}{{ $last ? '' : ', ' }}</span>
+                            </td>
                         </tr>
                     </table>
                 </div>


### PR DESCRIPTION
## MSEntraID new analyzers

**Breaking:** none.

**Fixed:**
- Removed dead code: a stray `#import json`, a commented-out debug URL, and a
  commented-out no-op block in `artifacts()`.
- `getUserInfo` template showed an empty "Plan Name" column: it expected
  `license.servicePlanName`, but the code sends `license.servicePlans` (a list — one SKU
  can bundle several service plans). Template now lists the service plan names per SKU.

**Added:**
- **`getDirectoryRoles`** : lists Entra ID directory roles (built-in admin roles) directly
  assigned to a user via `transitiveMemberOf`; flags known highly-privileged roles
  (Global Administrator, Privileged Role Administrator, etc.) as `suspicious`. No new
  permission required (reuses `Directory.Read.All`). 
- **`getSignInsByIP`** : new `ip` observable type; pivots from a suspicious source IP to
  every account that signed in from it tenant-wide, surfacing distinct-user count and
  failed/risky sign-ins (credential stuffing / password spray pattern). Reuses
  `AuditLog.Read.All`.
- **`getRiskyUser`** : combines Identity Protection's `riskyUsers` (current risk state)
  and `riskDetections` (history) for a user. Requires Entra ID P1 (detections) / P2
  (current state) and two new permissions (`IdentityRiskyUser.Read.All`,
  `IdentityRiskEvent.Read.All`). The two Graph calls are independent, each degrading to an
  explanatory message rather than failing the analyzer if the tenant isn't licensed or the
  app is missing one of the two permissions.
- Added TheHive long-report templates (`thehive-templates/MSEntraID_Get{DirectoryRoles,SignInsByIP,RiskyUser}_1_0/long.html`) for the three new analyzers, matching the existing panel/badge style. 

Tested against a local TheHive/Cortex instance and an EntraID tenant with P2 license.
