### PR TITLE
MSEntraID responders - Fix missing dataType check & update datetime usage

### DIFF
--- a/responders/MSEntraID/MSEntraID.py
+++ b/responders/MSEntraID/MSEntraID.py
@@ -94,7 +94,7 @@ class MSEntraID(Responder):
                     if r.status_code != 200:
                         self.error(f'Failure to revoke access tokens of user {self.user}: {r.content}')
                     else:
-                        self.time = datetime.datetime.utcnow()
+                        self.time = datetime.datetime.now(datetime.timezone.utc)
                 except Exception:
                     self.error(traceback.format_exc())
                 
@@ -124,21 +124,24 @@ class MSEntraID(Responder):
                 self.error('Incorrect dataType. "mail" expected.')
         
         elif self.service == "forcePasswordResetWithMFA":
-            try:
-                self.user = self.get_param('data.data', None, 'No UPN supplied for password reset with MFA')
-                if not self.user:
-                    self.error("No user supplied")
-                self.ensure_guid(headers, base_url)
+            if self.get_param('data.dataType') == 'mail':
+                try:
+                    self.user = self.get_param('data.data', None, 'No UPN supplied for password reset with MFA')
+                    if not self.user:
+                        self.error("No user supplied")
+                    self.ensure_guid(headers, base_url)
 
-                data = {"passwordProfile": {"forceChangePasswordNextSignIn": True, "forceChangePasswordNextSignInWithMfa": True}}
-                r = requests.patch(f"{base_url}users/{self.guid}", headers=headers, json=data)
-                
-                if r.status_code != 204:
-                    self.error(f'Failure to reset password with MFA for user {self.user}: {r.content}')
-                
-                self.report({"message": f"Password reset initiated for user {self.user}, user will be prompted for MFA and password change at next sign-in"})
-            except Exception:
-                self.error(traceback.format_exc())
+                    data = {"passwordProfile": {"forceChangePasswordNextSignIn": True, "forceChangePasswordNextSignInWithMfa": True}}
+                    r = requests.patch(f"{base_url}users/{self.guid}", headers=headers, json=data)
+
+                    if r.status_code != 204:
+                        self.error(f'Failure to reset password with MFA for user {self.user}: {r.content}')
+
+                    self.report({"message": f"Password reset initiated for user {self.user}, user will be prompted for MFA and password change at next sign-in"})
+                except Exception:
+                    self.error(traceback.format_exc())
+            else:
+                self.error('Incorrect dataType. "mail" expected.')
                        
         elif self.service == "enableUser":
             if self.get_param('data.dataType') == 'mail':

--- a/responders/MSEntraID/requirements.txt
+++ b/responders/MSEntraID/requirements.txt
@@ -1,3 +1,2 @@
 cortexutils
 requests
-datetime


### PR DESCRIPTION
## Summary
- Fix `forcePasswordResetWithMFA`: it was the only one of the 5 responder actions not checking `dataType == 'mail'` before running, so it could execute against non-mail observables with a confusing Graph 404 instead of a clear error.
- Modernize `datetime.datetime.utcnow()` (deprecated since Python 3.12) to `datetime.datetime.now(datetime.timezone.utc)`.
- Drop the unnecessary `datetime` entry from `requirements.txt` (it's a stdlib module, not a pip package).

Tested against TheHive/Cortex local instances and a P2 licensed EntraID tenant. 
