### PR TITLE
LdapQuery 3.1 - Add configurable TLS security level

### DIFF
--- a/analyzers/LdapQuery/Dockerfile
+++ b/analyzers/LdapQuery/Dockerfile
@@ -1,21 +1,13 @@
-# pull official base image
-FROM python:3.9-slim
+# Builder stage
+FROM python:3-slim AS builder
+WORKDIR /build
+COPY requirements.txt .
+RUN test ! -e requirements.txt || pip install --user --no-cache-dir -r requirements.txt
 
-# Set ARGS
-ARG ANALYZER_NAME
-
-# set work directory
-WORKDIR /app/
-
-# Copy the current directory contents into the container at /worker
+# Runtime stage
+FROM python:3-slim
+WORKDIR /worker
+COPY --from=builder /root/.local /root/.local
 COPY . LdapQuery/
-
-# install python3 pip3 and openssl
-RUN apt update
-RUN apt install python3 python3-pip openssl -y
-
-# install dependencies using builder
-RUN pip3 install -r LdapQuery/requirements.txt
-
-# Run app.py when the container launches
-ENTRYPOINT ["python","LdapQuery/ldapQuery.py"]
+ENV PATH=/root/.local/bin:$PATH
+ENTRYPOINT ["python", "LdapQuery/ldapQuery.py"]

--- a/analyzers/LdapQuery/LdapQuery.json
+++ b/analyzers/LdapQuery/LdapQuery.json
@@ -1,6 +1,6 @@
 {
   "name": "Ldap_Query",
-  "version": "3.0",
+  "version": "3.1",
   "author": "Florian Perret @cyber_pescadito & THA-CERT @tha_cert",
   "url": "https://github.com/cyberpescadito/Cortex-Analyzers/tree/master/analyzers/LdapQuery",
   "license": "AGPL-V3",
@@ -43,6 +43,13 @@
         "type": "string",
         "multi": false,
         "required": true
+    },
+    {
+        "name": "LDAP_tls_seclevel",
+        "description": "OpenSSL security level (0-5), lower to allow connecting to legacy LDAP/AD servers with old certificates or ciphers. Leave empty to use OpenSSL's default (2, requires >=2048-bit keys). '1' allows >=1024-bit keys and SHA-1 certs; '0' removes all restrictions, including unauthenticated ciphers. Only set this if you hit a TLS handshake failure against an older server; lowering it weakens transport security.",
+        "type": "string",
+        "multi": false,
+        "required": false
     },
     {
         "name": "uid_search_fields",

--- a/analyzers/LdapQuery/ldapQuery.py
+++ b/analyzers/LdapQuery/ldapQuery.py
@@ -44,18 +44,21 @@ class LdapQuery(Analyzer):
         # Get attributes to export as custom fields
         self.attributes_to_custom_fields, self.attributes_to_custom_fields_prefix = self.get_attribute_mapping("config.attributes_to_custom_fields")
 
+        tls_seclevel = self.get_param("config.LDAP_tls_seclevel", None)
+
         # Establish LDAP server connexion
         try:
-            # tls_configuration = Tls(
-            #     validate=ssl.CERT_REQUIRED,
-            #     version=ssl.PROTOCOL_TLSv1_2 # Or Version 1.3 if supported.
-            # )
+            tls_kwargs = {"validate": ssl.CERT_NONE}
+            if tls_seclevel:
+                # allows handshakes with older LDAP/AD certs OpenSSL 3.x rejects by default
+                tls_kwargs["ciphers"] = "DEFAULT@SECLEVEL={}".format(tls_seclevel)
+            tls_configuration = Tls(**tls_kwargs)
             s = Server(
                 ldap_address,
                 port=ldap_port,
                 get_info=ALL,
                 use_ssl=True if ldap_port == 636 else False,
-                # tls=tls_configuration if ldap_port == 636 else None,
+                tls=tls_configuration if ldap_port == 636 else None,
             )
             self.connection = Connection(
                 s,

--- a/thehive-templates/Ldap_Query_3_1/long.html
+++ b/thehive-templates/Ldap_Query_3_1/long.html
@@ -1,0 +1,70 @@
+<!-- Success: Dynamic display (limited to 5 results) -->
+<div ng-if="success && content.results.length > 0">
+    <div class="panel panel-success" ng-repeat="result in content.results | limitTo:5">
+      <div class="panel-heading">
+          <strong>{{ result.cn || result.uid || ('LDAP Result ' + ($index + 1)) }}</strong>
+      </div>
+      <div class="panel-body">
+          <dl class="dl-horizontal">
+              <div ng-if="result.cn">
+                  <dt>Full Name</dt>
+                  <dd class="wrap">{{result.cn}}</dd>
+              </div>
+              <div ng-if="result.mail">
+                  <dt>Email</dt>
+                  <dd class="wrap"><a href="mailto:{{result.mail}}">{{result.mail}}</a></dd>
+              </div>
+              <div ng-if="result.uid">
+                  <dt>UID</dt>
+                  <dd class="wrap">{{result.uid}}</dd>
+              </div>
+              <!-- Dynamically show other attributes -->
+              <div ng-repeat="(attr, value) in result" ng-if="attr !== 'cn' && attr !== 'mail' && attr !== 'uid'">
+                    <div>
+                        <dt>{{ attr | uppercase }}</dt>
+                        <dd class="wrap">{{ value }}</dd>
+                    </div>
+                </div> 
+          </dl>
+      </div>
+    </div>
+</div>
+  
+<!-- No results found -->
+<div class="panel panel-info" ng-if="success && content.results.length === 0">
+      <div class="panel-heading">
+          <strong>No results found</strong>
+      </div>
+      <div class="panel-body">
+          <p>No LDAP entries matched your query.</p>
+      </div>
+</div>
+  
+<!-- Filtered results -->
+<div class="panel panel-warning" ng-if="success && content.filtered">
+      <div class="panel-heading">
+          <strong>Filtered LDAP Query</strong>
+      </div>
+      <div class="panel-body">
+          <dl class="dl-horizontal">
+              <dt>Message</dt>
+              <dd class="wrap">{{content.filtered.message}}</dd>
+              <dt>Data</dt>
+              <dd class="wrap">{{content.filtered.data}}</dd>
+              <dt>Data type</dt>
+              <dd class="wrap">{{content.filtered.data_type}}</dd>
+              <dt>Whitelist</dt>
+              <dd class="wrap">{{content.filtered.whitelist}}</dd>
+          </dl>
+      </div>
+</div>
+  
+<!-- General error -->
+<div class="panel panel-danger" ng-if="!success">
+      <div class="panel-heading">
+          <strong>Error during LDAP query</strong>
+      </div>
+      <div class="panel-body">
+          <p>{{content.errorMessage}}</p>
+      </div>
+</div>  

--- a/thehive-templates/Ldap_Query_3_1/short.html
+++ b/thehive-templates/Ldap_Query_3_1/short.html
@@ -1,0 +1,3 @@
+<span class="label" ng-repeat="t in content.taxonomies" ng-class="{'info': 'label-info', 'safe': 'label-success', 'suspicious': 'label-warning', 'malicious':'label-danger'}[t.level]">
+    {{t.namespace}}:{{t.predicate}}={{t.value}}
+</span>


### PR DESCRIPTION
Tentative fix for #1443 

- Add an opt-in LDAP_tls_seclevel config to relax OpenSSL's default cipher security level, so operators can restore compatibility with legacy LDAP/AD servers without weakening TLS for everyone else.
- Restore up-to-date Dockerfile for security posture
