### PR TITLE
MSDefenderOffice365 - Fix SafeLinks host-detection bypass & misused error handling

### DIFF
--- a/analyzers/MSDefenderOffice365/README.md
+++ b/analyzers/MSDefenderOffice365/README.md
@@ -1,0 +1,32 @@
+# Microsoft Defender for Office 365 Analyzers
+
+This repository provides a set of **Cortex** analyzers related to Microsoft Defender for Office 365 (MDO).
+
+---
+
+## Overview of Analyzers
+
+### SafeLinksDecoder
+
+**Purpose**
+Decodes Microsoft Office 365 ATP Safe Links to extract the original destination URL. Safe Links is Microsoft's URL-wrapping service: outbound/inbound links are rewritten to point through a `*.safelinks.protection.outlook.com` gateway so they can be checked at time of click.
+
+**Key Points**
+- No API call, no credentials, no registration required — purely local URL parsing/decoding.
+- Detects a Safe Link by checking the URL's **host** (not just a substring anywhere in the URL) ends with `safelinks.protection.outlook.com`.
+- Tries several known wrapping patterns (`?url=`, `?data=`) and handles double URL-encoding (common in forwarded emails).
+- Creates `url` and `domain` artifacts for the decoded destination, so analysts can pivot on the real target.
+
+**Required Permissions**
+- None. This analyzer does not call any Microsoft API.
+
+**Sample Usage**
+- Run on TheHive's observable of type `url`.
+- If the observable isn't a Safe Link, the analyzer reports that explicitly (not an error).
+- If it is a Safe Link but no known wrapping pattern matches, the analyzer errors out.
+
+---
+
+## References
+
+- [Safe Links overview](https://learn.microsoft.com/en-us/defender-office-365/safe-links-about)

--- a/analyzers/MSDefenderOffice365/safelinks_decoder.py
+++ b/analyzers/MSDefenderOffice365/safelinks_decoder.py
@@ -76,9 +76,10 @@ class SafeLinksDecoder(Analyzer):
                     
                     return decoded_url
                     
-                except Exception as e:
-                    # Log error but don't stop - try next pattern
-                    self.error(f"Error decoding URL with pattern '{pattern}': {e}")
+                except Exception:
+                    # Decoding failed for this pattern - try the next one.
+                    # (self.error() would terminate the analyzer, which defeats
+                    # the point of trying further patterns.)
                     continue
         
         # No pattern matched - return None
@@ -87,21 +88,22 @@ class SafeLinksDecoder(Analyzer):
     def is_safelink(self, url: str) -> bool:
         """
         Check if the provided URL is a Microsoft Safe Link.
-        
-        Safe Links always contain 'safelinks.protection.outlook.com' in their domain,
-        regardless of region (nam, eur, can, aus, etc.)
-        
+
+        Safe Links always live on a '*.safelinks.protection.outlook.com' host,
+        regardless of region (nam, eur, can, aus, etc.). Checking against the
+        actual host (not the whole URL string) matters: a phishing URL can
+        embed that substring elsewhere (e.g. in a query parameter) to get
+        misclassified as a legitimate, already-vetted Safe Link.
+
         Args:
             url: The URL to check
-            
+
         Returns:
-            True if the URL is a Safe Link, False otherwise
+            True if the URL's host is a Safe Links domain, False otherwise
         """
-        return bool(re.search(
-            r'\.safelinks\.protection\.outlook\.com', 
-            url, 
-            re.IGNORECASE
-        ))
+        host = urllib.parse.urlparse(url).netloc.lower()
+        host = host.rsplit('@', 1)[-1].split(':', 1)[0]  # strip userinfo/port
+        return host == 'safelinks.protection.outlook.com' or host.endswith('.safelinks.protection.outlook.com')
 
     def run(self):
         """


### PR DESCRIPTION
## Summary
- Fix `is_safelink()`: it matched `safelinks.protection.outlook.com` anywhere
  in the URL string via unanchored regex, not the actual host. A phishing URL
  embedding that substring elsewhere (e.g. `https://evil.com/?next=https://x.
  safelinks.protection.outlook.com/?url=...`) could get misclassified as a
  legitimate, already-vetted Safe Link, with its "decoded" target trusted.
  Now checks the URL's real host via `urlparse`.
- Fix `decode_safelink()`: caught exceptions called `self.error()` with a
  comment saying it would "try the next pattern" but `self.error()`
  terminates the analyzer in cortexutils, so that never happened. Now just
  moves to the next pattern as intended.
- Add missing `README.md` for the analyzer (only one in the repo without one).