### PR TITLE
Add Elastic Security responder to sync alert statuses

### DIFF
--- a/responders/Elasticsearch/ElasticSecurity_AlertStatusSync.json
+++ b/responders/Elasticsearch/ElasticSecurity_AlertStatusSync.json
@@ -1,0 +1,137 @@
+{
+  "name": "ElasticSecurity_AlertStatusSync",
+  "version": "1.0",
+  "author": "Fabien Bloume, StrangeBee",
+  "url": "https://github.com/TheHive-Project/Cortex-Analyzers",
+  "license": "AGPL-V3",
+  "description": "Sync TheHive case/alert status back to the corresponding Elastic Security detection alert(s), including a closing reason",
+  "dataTypeList": [
+    "thehive:case",
+    "thehive:alert"
+  ],
+  "command": "Elasticsearch/ElasticSecurity_AlertStatusSync.py",
+  "baseConfig": "ElasticSecurity",
+  "config": {
+    "service": "sync"
+  },
+  "configurationItems": [
+    {
+      "name": "kibana_url",
+      "description": "Base Kibana URL, for example https://my-deployment.kb.eu-west-1.aws.found.io. Not the Elasticsearch URL",
+      "type": "string",
+      "multi": false,
+      "required": true,
+      "defaultValue": ""
+    },
+    {
+      "name": "api_key",
+      "description": "Kibana API key. Needs write access to Elastic Security alerts. Use this or username/password, not both",
+      "type": "string",
+      "multi": false,
+      "required": false,
+      "defaultValue": ""
+    },
+    {
+      "name": "username",
+      "description": "Kibana username, only if not using an API key",
+      "type": "string",
+      "multi": false,
+      "required": false,
+      "defaultValue": ""
+    },
+    {
+      "name": "password",
+      "description": "Kibana password, only if not using an API key",
+      "type": "string",
+      "multi": false,
+      "required": false,
+      "defaultValue": ""
+    },
+    {
+      "name": "verify_ssl",
+      "description": "Verify Kibana's TLS certificate. Disable only for self-signed or lab instances",
+      "type": "boolean",
+      "multi": false,
+      "required": false,
+      "defaultValue": true
+    },
+    {
+      "name": "space_id",
+      "description": "Kibana space holding the alerts. Leave empty for the default space",
+      "type": "string",
+      "multi": false,
+      "required": false,
+      "defaultValue": ""
+    },
+    {
+      "name": "custom_field_name_alert_id",
+      "description": "Custom field in TheHive holding the Elastic alert _id(s), comma separated if more than one. Falls back to the native sourceRef field when empty, which works for alerts imported by Elastic's stock TheHive connector because it sets sourceRef to the alert UUID, and that equals the alert _id. sourceRef does not exist on cases, so set this if the responder will ever run on a thehive:case",
+      "type": "string",
+      "multi": false,
+      "required": false,
+      "defaultValue": "elastic-alert-uuid"
+    },
+    {
+      "name": "status_new",
+      "description": "Elastic status for TheHive's 'New' stage. One of open, acknowledged, in-progress, closed",
+      "type": "string",
+      "multi": false,
+      "required": false,
+      "defaultValue": "open"
+    },
+    {
+      "name": "status_in_progress",
+      "description": "Elastic status for TheHive's 'InProgress' stage. Set to 'acknowledged' instead if your team treats acknowledgement as the working state",
+      "type": "string",
+      "multi": false,
+      "required": false,
+      "defaultValue": "in-progress"
+    },
+    {
+      "name": "status_imported",
+      "description": "Elastic status for TheHive's 'Imported' stage (alerts promoted to a case)",
+      "type": "string",
+      "multi": false,
+      "required": false,
+      "defaultValue": "in-progress"
+    },
+    {
+      "name": "status_closed",
+      "description": "Elastic status for TheHive's 'Closed' stage",
+      "type": "string",
+      "multi": false,
+      "required": false,
+      "defaultValue": "closed"
+    },
+    {
+      "name": "reason_map",
+      "description": "How a TheHive resolution status becomes an Elastic closing reason, as 'TheHiveStatus:elastic_reason' pairs (for example 'Contained:true_positive'). The full mapping is pre-filled with sensible defaults; edit, add or remove pairs as needed. Anything not listed here falls back to default_close_reason. Elastic's own reasons are false_positive, duplicate, true_positive, benign_positive, automated_closure and other, but any text up to 1024 characters is accepted. If this list is cleared entirely the built-in defaults are used",
+      "type": "string",
+      "multi": true,
+      "required": false,
+      "defaultValue": [
+        "FalsePositive:false_positive",
+        "TruePositive:true_positive",
+        "BenignPositive:benign_positive",
+        "Duplicated:duplicate",
+        "Duplicate:duplicate",
+        "Indeterminate:other",
+        "Ignored:other",
+        "Other:other"
+      ]
+    },
+    {
+      "name": "default_close_reason",
+      "description": "Closing reason used when a TheHive status has no mapping. Elastic's own values are false_positive, duplicate, true_positive, benign_positive, automated_closure and other, but any text up to 1024 characters is accepted",
+      "type": "string",
+      "multi": false,
+      "required": false,
+      "defaultValue": "other"
+    }
+  ],
+  "registration_required": true,
+  "subscription_required": true,
+  "free_subscription": true,
+  "integration_type": "external_api",
+  "service_homepage": "https://www.elastic.co/security"
+}

--- a/responders/Elasticsearch/ElasticSecurity_AlertStatusSync.py
+++ b/responders/Elasticsearch/ElasticSecurity_AlertStatusSync.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+from cortexutils.responder import Responder
+import requests
+
+# Fallback when reason_map config is empty; also mirrored into its JSON defaultValue.
+DEFAULT_REASON_MAP = {
+    "FalsePositive": "false_positive",
+    "TruePositive": "true_positive",
+    "BenignPositive": "benign_positive",
+    "Duplicated": "duplicate",
+    "Duplicate": "duplicate",
+    "Indeterminate": "other",
+    "Ignored": "other",
+    "Other": "other",
+}
+
+
+def normalize_id_list(value):
+    """Flatten a string or list custom-field value into a deduped list of ids."""
+    if value is None:
+        return []
+    items = [value] if isinstance(value, str) else list(value)
+    ids = []
+    seen = set()
+    for item in items:
+        if not item:
+            continue
+        for part in str(item).split(","):
+            part = part.strip()
+            if part and part not in seen:
+                seen.add(part)
+                ids.append(part)
+    return ids
+
+
+def parse_pairs(entries):
+    """Build a dict from 'key:value' config strings."""
+    mapping = {}
+    for entry in entries or []:
+        if not entry or ":" not in str(entry):
+            continue
+        key, _, value = str(entry).partition(":")
+        key, value = key.strip(), value.strip()
+        if key and value:
+            mapping[key] = value
+    return mapping
+
+
+class ElasticSecurity_AlertStatusSync(Responder):
+    def __init__(self):
+        Responder.__init__(self)
+        self.kibana_url = self.get_param("config.kibana_url", None, "Missing Kibana URL").rstrip("/")
+        self.api_key = self.get_param("config.api_key", None)
+        self.username = self.get_param("config.username", None)
+        self.password = self.get_param("config.password", None)
+        self.verify_ssl = self.get_param("config.verify_ssl", True)
+        self.space_id = self.get_param("config.space_id", None)
+        self.custom_field_name_alert_id = self.get_param("config.custom_field_name_alert_id", None)
+        # Which Elastic status each TheHive stage maps to is a local policy decision.
+        self.status_new = self.get_param("config.status_new", "open")
+        self.status_in_progress = self.get_param("config.status_in_progress", "in-progress")
+        self.status_imported = self.get_param("config.status_imported", "in-progress")
+        self.status_closed = self.get_param("config.status_closed", "closed")
+        self.reason_map = parse_pairs(
+            self.get_param("config.reason_map", None)
+        ) or dict(DEFAULT_REASON_MAP)
+        self.default_close_reason = self.get_param("config.default_close_reason", "other")
+
+        if not self.api_key and not (self.username and self.password):
+            self.error("Provide either an API key or a username and password")
+
+    @property
+    def status_url(self):
+        space = f"/s/{self.space_id}" if self.space_id else ""
+        return f"{self.kibana_url}{space}/api/detection_engine/signals/status"
+
+    def stage_to_status(self, stage):
+        return {
+            "New": self.status_new,
+            "InProgress": self.status_in_progress,
+            "Imported": self.status_imported,
+            "Closed": self.status_closed,
+        }.get(stage)
+
+    def get_alert_ids(self):
+        """Read the configured custom field, falling back to sourceRef (alerts only)."""
+        if self.custom_field_name_alert_id:
+            ids = normalize_id_list(
+                self.get_param(f"data.customFieldValues.{self.custom_field_name_alert_id}", None)
+            )
+            if ids:
+                return ids
+        return normalize_id_list(self.get_param("data.sourceRef", None))
+
+    def update_alerts(self, signal_ids, status, reason=None):
+        headers = {"Content-Type": "application/json", "kbn-xsrf": "cortex-responder"}
+        auth = None
+        if self.api_key:
+            headers["Authorization"] = f"ApiKey {self.api_key}"
+        else:
+            auth = (self.username, self.password)
+
+        payload = {"signal_ids": signal_ids, "status": status}
+        if reason and status == "closed":
+            payload["reason"] = reason
+
+        response = requests.post(
+            self.status_url, headers=headers, auth=auth, json=payload, verify=self.verify_ssl
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def run(self):
+        stage = self.get_param("data.stage", None, "Can't get case or alert stage")
+        status_value = self.get_param("data.status", None)
+        alert_ids = self.get_alert_ids()
+
+        if not alert_ids:
+            checked = (
+                [f"custom field '{self.custom_field_name_alert_id}'", "sourceRef"]
+                if self.custom_field_name_alert_id
+                else ["sourceRef"]
+            )
+            hint = (
+                " sourceRef is Alert-only in TheHive's schema; configure "
+                "custom_field_name_alert_id if this runs on cases."
+                if "thehive:case" in str(self.get_param("dataType", ""))
+                else ""
+            )
+            self.error(f"No Elastic alert ID found (checked: {', '.join(checked)}).{hint}")
+            return
+
+        status = self.stage_to_status(stage)
+        if status is None:
+            self.error(f"Unknown case/alert stage: {stage}")
+            return
+
+        reason = None
+        if status == "closed":
+            reason = self.reason_map.get(status_value, self.default_close_reason)
+
+        try:
+            result = self.update_alerts(alert_ids, status, reason)
+        except Exception as e:
+            self.error(f"Failed to update {len(alert_ids)} Elastic alert(s) to '{status}': {e}")
+            return
+
+        # Bulk call: partial success is in the response body, not an exception.
+        updated = result.get("updated", 0)
+        failures = result.get("failures", [])
+        conflicts = result.get("version_conflicts", 0)
+
+        if not updated:
+            self.error(
+                f"No Elastic alert was updated to '{status}'. Checked {len(alert_ids)} ID(s); "
+                f"they may not exist in this space. failures={failures} conflicts={conflicts}"
+            )
+            return
+
+        message = f"Set {updated}/{len(alert_ids)} Elastic alert(s) to '{status}'"
+        if reason:
+            message += f" with reason '{reason}'"
+        message += "."
+        if updated < len(alert_ids):
+            message += f" {len(alert_ids) - updated} ID(s) matched nothing."
+        if failures:
+            message += f" {len(failures)} failed."
+        if conflicts:
+            message += f" {conflicts} version conflict(s)."
+
+        self.report({
+            "message": message,
+            "status": status,
+            "reason": reason,
+            "requested": alert_ids,
+            "updated": updated,
+            "failures": failures,
+            "version_conflicts": conflicts,
+        })
+
+
+if __name__ == "__main__":
+    ElasticSecurity_AlertStatusSync().run()

--- a/responders/Elasticsearch/README.md
+++ b/responders/Elasticsearch/README.md
@@ -1,0 +1,46 @@
+### Elastic Security Alert Status Sync
+
+`ElasticSecurity_AlertStatusSync` mirrors a TheHive case/alert stage onto the matching Elastic Security detection alert(s), via Kibana's [detection alert status](https://www.elastic.co/docs/api/doc/kibana/operation/operation-setalertsstatus) API. It runs on `thehive:case` / `thehive:alert`.
+
+It targets **Kibana**, not Elasticsearch (that's the `Elasticsearch_Analysis` analyzer) — different URL and credentials, hence the separate `ElasticSecurity` baseConfig.
+
+#### Alert ID source
+
+1. If `custom_field_name_alert_id` is set, the responder reads that custom field. Required when running on a **case**.
+2. Otherwise it falls back to TheHive's native `sourceRef`. This works for alerts imported by Elastic's stock TheHive connector (it sets `sourceRef` to the alert UUID, which equals the detection alert `_id`), but `sourceRef` does not exist on cases.
+
+Either source may hold one `_id` or a comma-separated list; merged-alert cases producing a list are handled automatically.
+
+We recommend using custom fields, which is `elastic-alert-uuid` by default.
+
+#### Status mapping
+
+Elastic's status enum is fixed (`open`, `acknowledged`, `in-progress`, `closed`); which one each TheHive stage means is configurable:
+
+| TheHive stage | Config item | Default |
+|---|---|---|
+| New | `status_new` | `open` |
+| InProgress | `status_in_progress` | `in-progress` |
+| Imported | `status_imported` | `in-progress` |
+| Closed | `status_closed` | `closed` |
+
+#### Closing reasons
+
+When the resulting status is `closed`, a reason is sent (Elastic ignores it otherwise). The `reason_map` config item holds the full `TheHiveStatus:elastic_reason` mapping, pre-filled with:
+
+| TheHive status | Elastic reason |
+|---|---|
+| FalsePositive | `false_positive` |
+| TruePositive | `true_positive` |
+| BenignPositive | `benign_positive` |
+| Duplicated / Duplicate | `duplicate` |
+| Indeterminate / Ignored / Other | `other` |
+
+Edit, add or remove pairs as needed (for example, `Contained:true_positive` for a custom status). Unmapped statuses fall back to `default_close_reason` (`other`). Clearing `reason_map` entirely restores the built-in defaults. Elastic's own reasons are `false_positive`, `duplicate`, `true_positive`, `benign_positive`, `automated_closure` and `other`, but any string up to 1024 chars is accepted.
+
+#### Setup
+
+- Create a Kibana API key that can write to Elastic Security alerts (`.alerts-security.alerts-*`), or use basic auth — one or the other, not both.
+- `kibana_url` is the Kibana endpoint, not Elasticsearch. On Elastic Cloud these are different hostnames.
+- Set `space_id` if alerts live in a non-default Kibana space.
+- Populate `custom_field_name_alert_id`'s field with the Elastic alert `_id` at alert creation.

--- a/responders/Elasticsearch/requirements.txt
+++ b/responders/Elasticsearch/requirements.txt
@@ -1,0 +1,2 @@
+cortexutils
+requests


### PR DESCRIPTION
Add Elastic Security responder to sync alert statuses from TheHive to Elastic.

Useful with a notification rule on stage change, as well as a custom field set in TheHive.