### PR TITLE
Add Suspicious_Verdict Responder

### DIFF
--- a/responders/Suspicious/README.md
+++ b/responders/Suspicious/README.md
@@ -1,0 +1,116 @@
+# Suspicious_Verdict
+
+## Overview
+
+**Suspicious_Verdict** synchronizes triage decisions made on a **TheHive** Case or Alert with [**Suspicious**](https://github.com/thalesgroup-cert/suspicious), the case management platform developed and operated by **Thales CERT (THA-CERT)**.
+
+When an analyst adds a verdict tag (`SAFE`, `SUSPICIOUS`, or `DANGEROUS`) to a Case or Alert in TheHive, running this responder automatically updates the corresponding investigation in Suspicious. This eliminates the need to manually copy the verdict from one platform to the other.
+
+|                     |                                                                               |
+| ------------------- | ----------------------------------------------------------------------------- |
+| **Author**          | THA-CERT // EBA                                                               |
+| **License**         | AGPL-V3                                                                       |
+| **Data types**      | `thehive:case`, `thehive:alert`                                               |
+| **Related project** | [thalesgroup-cert/suspicious](https://github.com/thalesgroup-cert/suspicious) |
+
+## How it works
+
+The responder follows these steps:
+
+1. **Identify the Suspicious investigation.**
+   The responder extracts the Suspicious case ID from the TheHive Case or Alert **title**. The title is expected to contain a pattern such as `... #1234 - <description>`.
+
+2. **Read the verdict tag.**
+   The responder checks the Case or Alert tags for exactly one tag matching `suspicious:verdict="<VALUE>"`, where `<VALUE>` must be `SAFE`, `SUSPICIOUS`, or `DANGEROUS` (see [Taxonomy](#taxonomy)).
+
+3. **Update the Suspicious investigation.**
+   The responder sends a `PATCH` request to:
+
+   ```text
+   {suspicious_url}/api/investigations/{suspicious_case_id}/edit-global/
+   ```
+
+   with the following payload:
+
+   ```json
+   {
+     "score": 10,
+     "confidence": 100,
+     "classification": "<VALUE>"
+   }
+   ```
+
+4. **Mark the item as processed.**
+   Once Suspicious returns a successful `200` response, the responder adds the `suspicious:status="challenge_reviewed."` tag to the Case or Alert and reports a confirmation message in TheHive.
+
+### Error handling
+
+The responder fails explicitly, with the error visible in the TheHive task log, in any of the following cases:
+
+* the Case or Alert ID is missing from the payload;
+* no Suspicious case ID can be extracted from the title;
+* the Case or Alert has no tags;
+* multiple `suspicious:verdict=` tags are present;
+* no valid `suspicious:verdict=` tag is found;
+* the Suspicious API request fails, either because of a non-`200` response or a network error.
+
+## Taxonomy
+
+This responder uses the `suspicious` taxonomy provided with the project (`taxonomy/machinetag.json`). Import this taxonomy into TheHive to make the three verdict values available through tag auto-completion, each with its own colour.
+
+| Tag                               | Meaning                                                   | Colour       |
+| --------------------------------- | --------------------------------------------------------- | ------------ |
+| `suspicious:verdict="SAFE"`       | The Case or Alert is classified as **Safe** in Suspicious | 🟢 `#00ad1c` |
+| `suspicious:verdict="SUSPICIOUS"` | The Case or Alert is classified as **Suspicious**         | 🟠 `#ffa800` |
+| `suspicious:verdict="DANGEROUS"`  | The Case or Alert is classified as **Dangerous**          | 🔴 `#ff0000` |
+
+An analyst only needs to add the appropriate verdict tag to the Case or Alert and run the responder, either manually or automatically (see below).
+
+## Configuration
+
+| Name               | Type   | Required | Description                                                       |
+| ------------------ | ------ | -------- | ----------------------------------------------------------------- |
+| `suspicious_url`   | string | Yes      | Base URL of the Suspicious instance, e.g. `http://localhost:9020` |
+| `suspicious_token` | string | Yes      | Suspicious API token used for authentication                      |
+
+Configure these values under **Organization → Responders → Suspicious_Verdict** in Cortex, then enable the responder for your TheHive organization.
+
+## Usage
+
+### Manual trigger
+
+To run the responder manually:
+
+1. Add the appropriate verdict tag to the Case or Alert, for example `suspicious:verdict="DANGEROUS"`.
+2. From the Case or Alert view in TheHive, run the **Suspicious_Verdict** responder.
+3. The corresponding Suspicious investigation is updated, and the Case or Alert is tagged `suspicious:status="challenge_reviewed."`.
+
+### Automatic trigger (optional)
+
+Running the responder manually after every verdict update can easily be overlooked. TheHive supports **notifications** that can automatically run a responder when a matching event occurs — in this case, when a `suspicious:verdict=` tag is added to a Case or Alert.
+
+The corresponding notification definition, **Run Suspicious_Verdict Responder**, is provided separately in the [`StrangeBee/integrations`](https://github.com/StrangeBeeCorp/integrations) repository, under `integrations/vendors/Suspicious/thehive/functions`, along with a dedicated README explaining how to import and configure it in TheHive.
+
+➡️ See **StrangeBee/integrations — Run Suspicious_Verdict Responder** for the fully automated workflow:
+
+**tag added → responder runs → Suspicious investigation updated**
+
+No manual action is required once the notification is configured.
+
+## Requirements
+
+```text
+requests
+cortexutils
+```
+
+## Files in this responder
+
+```text
+Suspicious_Verdict/
+├── suspicious_verdict.py
+├── Suspicious_Verdict.json
+├── requirements.txt
+├── README.md
+└── taxonomy/
+    └── machinetag.json

--- a/responders/Suspicious/Suspicious_Verdict.json
+++ b/responders/Suspicious/Suspicious_Verdict.json
@@ -1,0 +1,27 @@
+{
+  "name": "Suspicious_Verdict",
+  "version": "1.0",
+  "author": "THA-CERT // EBA",
+  "url": "https://github.com/thalesgroup-cert/suspicious",
+  "license": "AGPL-V3",
+  "description": "Classifies cases or alerts on the Suspicious platform.",
+  "dataTypeList": ["thehive:case", "thehive:alert"],
+  "command": "Suspicious/suspicious_verdict.py",
+  "baseConfig": "Suspicious",
+  "configurationItems": [
+    {
+      "name": "suspicious_url",
+      "description": "Suspicious Base URL, e.g.,  http://localhost:9020",
+      "type": "string",
+      "multi": false,
+      "required": true
+    },
+    {
+      "name": "suspicious_token",
+      "description": "Suspicious API token for authentication",
+      "type": "string",
+      "multi": false,
+      "required": true
+    }
+  ]
+}

--- a/responders/Suspicious/requirements.txt
+++ b/responders/Suspicious/requirements.txt
@@ -1,0 +1,2 @@
+requests
+cortexutils

--- a/responders/Suspicious/suspicious_verdict.py
+++ b/responders/Suspicious/suspicious_verdict.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# Author: THA-CERT // EBA
+
+import requests
+import re
+from cortexutils.responder import Responder
+
+class Suspicious_Verdict(Responder):
+    def __init__(self):
+        Responder.__init__(self)
+
+        self.suspicious_url = self.get_param("config.suspicious_url", "http://localhost:9020")
+        self.suspicious_token = self.get_param("config.suspicious_token", "Missing Suspicious API Key")
+
+        self.thehive_id = self.get_param("data.id")
+        self.thehive_tags = self.get_param("data.tags", [])
+        self.thehive_title = self.get_param("data.title", "")
+        self.thehive_type = self.get_param("data._type", "case").lower()
+
+    def run(self):
+        Responder.run(self)
+
+        if not self.thehive_id:
+            self.error(f"Unable to find the {self.thehive_type.capitalize()} ID in the payload.")
+
+        suspicious_case_id = re.search(r"#(\d+)(?=\s-)", self.thehive_title)
+
+        if suspicious_case_id:
+            suspicious_case_id = suspicious_case_id.group(1)
+        else:
+            self.error(f"Unable to find the Suspicious Case ID in the {self.thehive_type} title.")
+            
+        if not self.thehive_tags:
+            self.error(f"No tags attached to the TheHive {self.thehive_type} : {self.thehive_id} .")
+            
+        verdicts = [tag for tag in self.thehive_tags if tag.startswith('suspicious:verdict=')]
+
+        if len(verdicts) > 1:
+            self.error(f"There are multiple verdict tags on this {self.thehive_type}! Please keep only one : {verdicts}")
+
+        if 'suspicious:verdict="DANGEROUS"' in self.thehive_tags:
+            suspicious_verdict = "DANGEROUS"
+            self.request(suspicious_case_id, suspicious_verdict)
+
+        elif 'suspicious:verdict="SAFE"' in self.thehive_tags:
+            suspicious_verdict = "SAFE"
+            self.request(suspicious_case_id, suspicious_verdict)
+
+        elif 'suspicious:verdict="SUSPICIOUS"' in self.thehive_tags:
+            suspicious_verdict = "SUSPICIOUS"
+            self.request(suspicious_case_id, suspicious_verdict)
+
+        else:
+            self.error(f"No valid Suspicious verdict tag found in the Thehive {self.thehive_type} : {self.thehive_id} .")
+
+    def request(self, suspicious_case_id, suspicious_verdict):
+        url = f"{self.suspicious_url}/api/investigations/{suspicious_case_id}/edit-global/"
+
+        headers = {
+            "accept": "application/json",
+            "Authorization": f"Token {self.suspicious_token}"
+        }
+
+        payload = {
+            "score": 10,
+            "confidence": 100,
+            "classification": f"{suspicious_verdict}"
+        }
+
+        try:
+            response = requests.patch(
+                url,
+                headers=headers,
+                json=payload,
+                verify=False
+            )
+
+            if response.status_code == 200:
+                self.report(
+                    {"message": f"Suspicious Case : {suspicious_case_id} has been classified as {suspicious_verdict}."})
+            else:
+                self.error(f"Error : {response.text}")
+
+        except requests.exceptions.RequestException as e:
+            self.error(f"Error during the request : {str(e)}")
+
+    def operations(self, raw):
+        new_tag = 'suspicious:status="challenge_reviewed."'
+
+        if self.thehive_type == "alert":
+            return [
+                self.build_operation("AddTagToAlert", tag=new_tag)
+            ]
+        else:
+            return [
+                self.build_operation("AddTagToCase", tag=new_tag)
+            ]
+
+if __name__ == '__main__':
+    Suspicious_Verdict().run()

--- a/responders/Suspicious/taxonomy/machinetag.json
+++ b/responders/Suspicious/taxonomy/machinetag.json
@@ -1,0 +1,40 @@
+{
+  "namespace": "suspicious",
+  "description": "Suspicious taxonomy provides standardized tags for case management operations and automated TheHive/Cortex responders.",
+  "version": 1,
+  "exclusive": false,
+  "expanded": "Suspicious Management",
+  "refs": [
+    "https://github.com/thalesgroup-cert/suspicious"
+  ],
+  "predicates": [
+    {
+      "value": "verdict",
+      "expanded": "Verdict",
+      "description": "Classifies cases as Safe, Suspicious, or Dangerous.",
+      "exclusive": true
+    }
+  ],
+  "values": [
+    {
+      "predicate": "verdict",
+      "entry": [
+        {
+          "value": "SAFE",
+          "expanded": "SAFE - Classification",
+          "colour": "#00ad1c"
+        },
+        {
+          "value": "SUSPICIOUS",
+          "expanded": "SUSPICIOUS - Classification",
+          "colour": "#ffa800"
+        },
+        {
+          "value": "DANGEROUS",
+          "expanded": "DANGEROUS - Classification",
+          "colour": "#ff0000"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds **Suspicious_Verdict**, a Responder that pushes the triage verdict (`SAFE` / `SUSPICIOUS` / `DANGEROUS`) set on a TheHive Case or Alert to the matching investigation in [Suspicious](https://github.com/thalesgroup-cert/suspicious), the case management platform maintained by Thales CERT.

## What's included

- `responders/Suspicious_Verdict/suspicious_verdict.py` — responder logic
- `responders/Suspicious_Verdict/Suspicious_Verdict.json` — service interaction file
- `responders/Suspicious_Verdict/requirements.txt` — `requests`, `cortexutils`
- `responders/Suspicious_Verdict/taxonomy/machinetag.json` — `suspicious` taxonomy
  (verdict tags: SAFE / SUSPICIOUS / DANGEROUS)
- `responders/Suspicious_Verdict/README.md` — full documentation (behaviour,
  taxonomy table, configuration, manual and automatic triggering)

## Verification performed

- ✅ Tested with a valid configuration (`suspicious_url`, `suspicious_token`) against a live Suspicious instance: verdict tags correctly update the investigation's classification, score and confidence.
- ✅ Tested with missing configuration: the responder raises an explicit Cortex error instead of failing silently.
- ✅ Tested with a Case/Alert missing tags, missing a valid verdict tag, or containing several verdict tags at once: each case returns an explicit error message.
- ✅ Tested on both `thehive:case` and `thehive:alert` data types.

## Related contribution

A companion TheHive **notification** that automatically triggers this responder when a `suspicious:verdict=` tag is added is submitted separately in `StrangeBee/integrations` (folder `integrations/vendors/Suspicious/thehive/functions`), as that repository is the one scoped to TheHive notifications/integrations. Both READMEs cross-reference each other.